### PR TITLE
Labels for PRs can get copied over from linked issue

### DIFF
--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Controllers/WebhookIssueController.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Controllers/WebhookIssueController.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                 if (data.Label != null && !string.IsNullOrEmpty(data.Label.Name))
                 {
                     string labelName = data.Label.Name;
-                    if (labelName.StartsWith("area-"))
+                    if (labelName.StartsWith("area-", StringComparison.OrdinalIgnoreCase))
                     {
                         Logger.LogInformation($"! Area label {labelName} for {issueOrPr} {issueOrPullRequest.Number} got {data.Action}.");
                     }


### PR DESCRIPTION
- [x] adds capability to set area label from linked issue for PRs (cc @ericstj for requested issue)
- [x] does case insensitive comparison on area-* prefix, (e.g. allowing for Area-IDE) (cc @jaredpar for dotnet/roslyn)

Fixes https://github.com/dotnet/issue-labeler/issues/2