### PR TITLE
Doc improvement to onboarding steps.

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -14,7 +14,7 @@ This issue-labeler uses [ML.NET](https://github.com/dotnet/machinelearning) to h
   - Get top-N label predictions
   - Enable automatic label assignments
 
-## Download/Train ML models
+## How we Download/Train ML models
 
 We use GraphQL and [Octokit](https://www.nuget.org/packages/Octokit/) to download issues from GitHub and then train models using [ML.NET](ML.NET). e.g. dotnet/runtime repository has been trained on over 30,000 issues, and 5,000 PRs which have been labeled in the past, either manually or automatically.
 
@@ -32,14 +32,14 @@ The [CreateMikLabelModel](https://github.com/dotnet/issue-labeler/tree/master/sr
 
 As seen in [commit](https://github.com/dotnet/issue-labeler/commit/77e4dbc45184f34e940c0f3cba57160e30c2c183), the [ExperimentModifier](https://github.com/maryamariyan/issue-labeler-2/blob/213a96cf88d31333295126e7815c4688c2e31b54/src/CreateMikLabelModel/ML/ExperimentModifier.cs) class in CreateMikLabelModel project helps configure how the models should be trained (what column information to use (e.g. issue Description), how to treat them (as Text, Categorical data, Numeric or Ignore), how long to let the experiment run, and which algorithms to let AutoML consider while training (FastTreeOva, LightGbm, etc.)).
 
-## Pack ML models into nuget
+## [Archived] Pack ML models into nuget
 
 In the past we used to pack the resulting models into a nuget package called `Microsoft.DotNet.GitHubIssueLabeler.Assets` to be easily consumable within a web application. But now we have retired the nuget package and instead use Azure Blob Storage to upload the models for use in the application.
 
-#### About Microsoft.DotNet.GitHub.IssueLabeler project
+#### About the `Microsoft.DotNet.GitHub.IssueLabeler` project
 
 The [Microsoft.DotNet.GitHub.IssueLabeler](https://github.com/dotnet/issue-labeler/tree/master/src/Microsoft.DotNet.GitHub.IssueLabeler) project is the web application that uses ML models created using CreateMikLabelModel to predict area labels. Given repository owner/name/number combination, the IssueLabeler app provides an API returning top three predictions along with their confidence score. This information is computed using the ML models loaded in memory uploaded from Azure Blob Storage, which we produced in CreateMikLabelerModel project.
-Since dotnet/runtime has a big set of area owners and contributors, we decided to use an automatic assignemnt for issues and PRs. In order to achieve automatic label assignments, the IssueLabeler app, listens to all issue and PR creations via a webhook setting and finds top three predictions and only when the top prediction score has above 40% confidence, then this labeler app is allowed to automatically add that area label name to the newly created issue or PR. For dotnet/aspnetcore however, this webhook is not active and instead, the aspnetcore repository uses the hubbup web app to allow for manual area label assignment. Rather than doing automatic assignments, the hubbup app provides a nice UI for the prediction results it receives from [Microsoft.DotNet.GitHub.IssueLabeler](https://github.com/dotnet/issue-labeler/tree/master/src/Microsoft.DotNet.GitHub.IssueLabeler).
+Since dotnet/runtime has a big set of area owners and contributors, we decided to use an automatic assignment for issues and PRs. In order to achieve automatic label assignments, the IssueLabeler app, listens to all issue and PR creations via a webhook setting and finds top three predictions and only when the top prediction score has above 40% confidence, then this labeler app is allowed to automatically add that area label name to the newly created issue or PR. For dotnet/aspnetcore however, this webhook is not active and instead, the aspnetcore repository uses the hubbup web app to allow for manual area label assignment. Rather than doing automatic assignments, the hubbup app provides a nice UI for the prediction results it receives from [Microsoft.DotNet.GitHub.IssueLabeler](https://github.com/dotnet/issue-labeler/tree/master/src/Microsoft.DotNet.GitHub.IssueLabeler).
 
 #### About the public-dispatcher branch
 
@@ -54,7 +54,7 @@ Based on the above diagram we can publish multiple apps using the same source co
 ### Prerequisites
 
 * Create a [GitHub Personal Access Token](https://github.com/settings/tokens) that includes the `repo:public_repo` scope (to access public repositories)
-* Register that token on your machine with the command: `dotnet user-secrets set GitHubAccessToken "{{ghp_token_value}}"`
+* Register that token on your machine by first navigating to the `src\CreateMikLabelModel` folder, which contains the project file needing `GitHubAccessToken`, then add the user secret with the command: `dotnet user-secrets set GitHubAccessToken "{{ghp_token_value}}"`. For more information refer to docs on enabling secret storage [here](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-6.0&tabs=windows#enable-secret-storage).
 
 ### Execution
 

--- a/src/LabelPredictor/Microsoft.DotNet.Github.LabelPredictor.csproj
+++ b/src/LabelPredictor/Microsoft.DotNet.Github.LabelPredictor.csproj
@@ -2,7 +2,7 @@
 
 	<Import Project="..\..\eng\Versions.props" />
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<SignAssembly>false</SignAssembly>
 		<ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
 		<WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>


### PR DESCRIPTION
Also fixes compile on main branch: Setting target framework for `M.D.G.LabelPredictor` project to net6.0 to match with other projects

FYI this PR updated projects to net6.0: https://github.com/dotnet/issue-labeler/pull/31 and this PR refactored some logic into this new LabelPredictor project https://github.com/dotnet/issue-labeler/pull/36.