### PR TITLE
Call CreateIfNotExists(PublicAccessType.None) instead of Blob

### DIFF
--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/AzureBlobModelHolder.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/AzureBlobModelHolder.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
 
             _logger.LogInformation($"! calling {nameof(BlobContainerClient)}.");
             BlobContainerClient container = new BlobContainerClient(_connectionString, _blobContainerName);
-            container.CreateIfNotExists(PublicAccessType.Blob);
+            container.CreateIfNotExists(PublicAccessType.None);
 
             try
             {


### PR DESCRIPTION
The storage account where label prediction models are stored is configured to not have any public access, so we have to use the right API to avoid errors saying that we can't create public blobs in a private account. It isn't clear how/why this ever worked, but this change does reflect the current app/storage settings.

@maryamariyan - this is the fix that I talked about, and it's working in production.