### PR TITLE
3 small fixes: strip newlines from issue titles, fix warning, and add dotnet/msbuild repo

### DIFF
--- a/src/CreateMikLabelModel/DL/GraphQLDownloadHelper.cs
+++ b/src/CreateMikLabelModel/DL/GraphQLDownloadHelper.cs
@@ -184,12 +184,13 @@ namespace CreateMikLabelModel.DL
             var author = issue.Author != null ? issue.Author.Login : DeletedUser;
             var area = issue.Labels.Nodes.First(l => LabelHelper.IsAreaLabel(l.Name)).Name;
             var body = issue.BodyText.Replace('\r', ' ').Replace('\n', ' ').Replace('\t', ' ').Replace('"', '`');
+            var title = issue.Title.Replace('\r', ' ').Replace('\n', ' ').Replace('\t', ' ').Replace('"', '`');
             var createdAt = issue.CreatedAt.UtcDateTime.ToFileTimeUtc();
             if (issueType == IssueType.Issue)
             {
                 outputLines.Add(
                     (issue.CreatedAt, issue.Number, repo),
-                    $"{createdAt},{repo},{issue.Number}\t{issue.Number}\t{area}\t{issue.Title}\t{body}\t{author}\t0\t");
+                    $"{createdAt},{repo},{issue.Number}\t{issue.Number}\t{area}\t{title}\t{body}\t{author}\t0\t");
             }
             else if (issueType == IssueType.PullRequest && issue is PullRequestsNode pullRequest)
             {
@@ -201,7 +202,7 @@ namespace CreateMikLabelModel.DL
 
                 outputLines.Add(
                     (issue.CreatedAt, issue.Number, repo),
-                    $"{createdAt},{repo},{issue.Number}\t{pullRequest.Number}\t{area}\t{pullRequest.Title}\t{body}\t{author}\t1\t{filePaths}");
+                    $"{createdAt},{repo},{issue.Number}\t{pullRequest.Number}\t{area}\t{title}\t{body}\t{author}\t1\t{filePaths}");
             }
             else
             {

--- a/src/CreateMikLabelModel/DL/OctokitDownloadHelper.cs
+++ b/src/CreateMikLabelModel/DL/OctokitDownloadHelper.cs
@@ -77,7 +77,7 @@ namespace CreateMikLabelModel.DL
             catch (Exception rex)
             {
                 Trace.WriteLine(rex.Message);
-                throw rex;
+                throw;
             }
         }
 

--- a/src/CreateMikLabelModel/repos.json
+++ b/src/CreateMikLabelModel/repos.json
@@ -34,6 +34,9 @@
       "dotnet/maui"
     ],
     [
+      "dotnet/msbuild"
+    ],
+    [
       "NuGet/Home"
     ]
   ]


### PR DESCRIPTION
3 fixes:

1. Remove invalid characters from issue titles - Apparently newlines are valid in GitHub issue titles! This code makes sure they are stripped out, or else it breaks the TSV file because it has extra newlines.
2. Fix compiler warning about re-throwing an exception
3. Add dotnet/msbuild to repos.json

The first change is very important because some repos (dotnet/aspnetcore) have newlines (hex 0x0A) in issue titles! Yes, GitHub actually allows that! There was exactly 1 place where we weren't stripping those characters so I fixed that. The other 2 are just minor fixes/improvements.