### PR TITLE
Update labeler docs on how to create a labeler, update models, etc.

### DIFF
--- a/Documentation/Implementation.md
+++ b/Documentation/Implementation.md
@@ -1,0 +1,35 @@
+
+# Implementation details
+
+The following sections help better understand how some of the projects in this repo work.
+
+## Downloading GitHub issue data and training ML models
+
+We use GraphQL and [Octokit](https://www.nuget.org/packages/Octokit/) to download issues from GitHub and then train models using [ML.NET](ML.NET). e.g. dotnet/runtime repository has been trained on over 30,000 issues, and 5,000 PRs which have been labeled in the past, either manually or automatically.
+
+## The CreateMikLabel project
+
+The [CreateMikLabelModel](https://github.com/dotnet/issue-labeler/tree/master/src/CreateMikLabelModel) project is responsible for:
+
+1. Downloading Github issues and pull requests
+2. Specifying which data to download (title, description, labels, author, mentions, PR file names, optionally PR diff etc.)
+3. Segmenting issue or PR records into train (first 80%), validate (second 10%), and test (last 10%) data.
+4. Customizing ML training settings: ML models to skip/consider (e.g. FastTreeOva), time to train, information to consider while training (e.g. number of file changes).
+5. Optionally testing the ML generated Models to help understand which area labels may be getting more missed predictions or lower confidence compared to others.
+
+## ML customization
+
+As seen in [commit](https://github.com/dotnet/issue-labeler/commit/77e4dbc45184f34e940c0f3cba57160e30c2c183), the [ExperimentModifier](https://github.com/maryamariyan/issue-labeler-2/blob/213a96cf88d31333295126e7815c4688c2e31b54/src/CreateMikLabelModel/ML/ExperimentModifier.cs) class in CreateMikLabelModel project helps configure how the models should be trained (what column information to use (e.g. issue Description), how to treat them (as Text, Categorical data, Numeric or Ignore), how long to let the experiment run, and which algorithms to let AutoML consider while training (FastTreeOva, LightGbm, etc.)).
+
+## The `Microsoft.DotNet.GitHub.IssueLabeler` project
+
+The [Microsoft.DotNet.GitHub.IssueLabeler](https://github.com/dotnet/issue-labeler/tree/master/src/Microsoft.DotNet.GitHub.IssueLabeler) project is the web application that uses ML models created using CreateMikLabelModel to predict area labels. Given repository owner/name/number combination, the IssueLabeler app provides an API returning top three predictions along with their confidence score. This information is computed using the ML models loaded in memory uploaded from Azure Blob Storage, which we produced in CreateMikLabelerModel project.
+Since dotnet/runtime has a big set of area owners and contributors, we decided to use an automatic assignment for issues and PRs. In order to achieve automatic label assignments, the IssueLabeler app, listens to all issue and PR creations via a webhook setting and finds top three predictions and only when the top prediction score has above 40% confidence, then this labeler app is allowed to automatically add that area label name to the newly created issue or PR. For dotnet/aspnetcore however, this webhook is not active and instead, the aspnetcore repository uses the hubbup web app to allow for manual area label assignment. Rather than doing automatic assignments, the hubbup app provides a nice UI for the prediction results it receives from [Microsoft.DotNet.GitHub.IssueLabeler](https://github.com/dotnet/issue-labeler/tree/master/src/Microsoft.DotNet.GitHub.IssueLabeler).
+
+## The public-dispatcher branch
+
+The public-dispatcher branch is the code base for the github app that gets installed per github organization. We would have one app instance per org (one for Microsoft and one for dotnet) based off the public-dispatcher branch. The github app would be able to query top three predictions in a distributed way from other app(s) based off of the main branch which are configured for one or more repository to provide prediction scores.
+
+![image](https://user-images.githubusercontent.com/5897654/154319795-35975683-c4ae-477d-8a7c-74ad3079f1ed.png)
+
+Based on the above diagram we can publish multiple apps using the same source code from main branch, where each app is responsible for giving predictions for one or more github repositories. But there would be only a single github app per github organization (e.g. dotnet) which has the webhook setup to update issue/PRs with labels by referring to prediction results from the one or more ML-based apps configured.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,64 +1,181 @@
+# DotNet Issue Labeler
+
+This document describes how to set up a new issue labeler app (for a new GitHub repo), as well as how to update the training data for an existing labeler app and repo.
+
+Note: Several parts of this document have steps that require particular membership and permissions for various GitHub repos, Azure subscriptions and resources, and so forth. You may have to request permissions or send PRs to make certain changes.
+
+## Add support for a new GitHub repo
+
+If your repo is not yet set up for issue labeling, there are two options:
+
+1. Use an existing labeler app that supports the same GitHub org and add your repo's data to it
+1. Create a new labeler app and add your repo's data to it
+
+Please note that a single labeler app can support only one org, so if your org isn't supported yet, you must create a new labeler app instance.
+
+If your are adding your repo to an existing labeler, see the [Web App Service List](#web-app-service-list) for a list of existing apps.
+
+Follow these steps to create a new labeler app:
+
+1. To create a new labeler, you must have access to the `GitHubIssueLabeller` resource group in the `DDFun IaaS Dev Shared Public` Azure Subscription. Contact the DevDiv Azure Ops email alias to request access.
+1. Go to the Azure Portal to create a new web app: https://ms.portal.azure.com/#create/Microsoft.WebSite
+1. Select these settings:
+   - **Subscription**: DDFun IaaS subscription
+   - **Resource Group**: GitHubIssueLabeller
+   - **Name**: Arbitrary, but try to follow a pattern like `nuget-home-labeler`
+   - **Publish**: Code
+   - **Runtime stack**: .NET 6 (LTS)
+   - **OS**: Windows
+   - **Region**: West US or similar is best, so that it is nearer to other resources in this resource group, and where there are existing App Service Plans that can be shared
+   - **App Service Plan**: If possible, pick an existing service plan (all apps in the same service plan share the same machine resources, so don't put "too much" into one). Otherwise create a new service plan of an appropriate size. How big is big enough? Memory is the largest concern, so start small, and upgrade to more memory if it runs out.
+1. Click **Review and Create**, and then **Create**
+1. Go to the new Web App resource you created
+1. Go to **Settings** / **Configuration**
+   - In General Settings make sure these are set:
+     - **Platform**: 64bit
+     - **Always on**: On
+     - And click **Save**
+   - In Application settings set the following common settings:
+     - `AppSecretUri`: Copy the value from any of the other labeler apps
+     - `BlobContainer`: `areamodels`
+     - `QConnectionString`: Copy the value from any of the other labeler apps
+     - `RepoOwner`: The owner of the repo as seen in the GitHub repo URL. For example, the repo `https://github.com/ABC/XYZ` would have `ABC` as the owner.
+     - `GitHubAppId`: Copy this from another labeler app that targets the *same* GitHub org (for example, the `dotnet`, `microsoft`, or `nuget` org)
+     - `InstallationId`: Copy this from another labeler app that targets the *same* GitHub org (for example, `dotnet`, `microsoft`, or `nuget` org)
+     - And click **Save**
+1. Go to **Settings** / **Identity**
+   - Under System Assigned, select **Status: On**, and click **Save**, and then **Yes**. This identity will enable the app to access Azure Key Vault secrets
+1. Configure Key Vault access
+   - In the same DDFun IaaS subscription, go to the **Mirror** Key Vault resource
+     - Select **Access Policies**
+     - Click **Create**
+     - Select the following **Secret Permissions**: `Get`, `List` (note: _not_ Key or Certificat permissions!)
+     - Click **Next**
+     - Search in the list for the Web App name that you created (example: `nuget-home-labeler`)
+     - Click **Next**
+     - Don't select anything for Application
+     - Click **Next**
+     - Click **Create**
+1. Publish the labeler app from Visual Studio
+   - Clone the https://github.com/dotnet/issue-labeler repo
+   - Open the **issue-labeler.sln** solution in Visual Studio
+   - Check that you can build the **Microsoft.DotNet.Github.IssueLabeler** project
+   - Right-click on the **Microsoft.DotNet.Github.IssueLabeler** project and select **Publish...**
+   - Create a new Publish Profile and select **Azure** as the target, then pick **Azure App Service (Windows)** as the specific target
+   - Select the **DDFun IaaS Dev Shared Public** subscription (formerly known as **DDITPublic**)
+   - Select the App Service instance that you created earlier (for example, `nuget-home-labeler`)
+   - Deployment type: Publish
+   - Click **Finish**, then **Close**
+   - In the Settings screen click one of the pencil icons to edit the Settings and make sure the following are set:
+     - **Configuration**: Release
+     - **Target framework**: net6.0
+     - **Deployment mode**: Self-contained
+     - **Target Runtime**: win-x64
+     - Click **Save**
+   - Click **Publish** (this will build the app and upload to Azure, and can take a few minutes)
+1. The publish operation should launch your web browser to its URL and you should see the message `Check the logs, or predict labels.`, indicating the app is running
+   - Note that the app is not yet configured to predict anything! It's just an app with no data.
+   - You will need to follow the steps to create and upload prediction models and configure the app to serve those predictions.
 
 
-## Intro to issue labeling
+## Create and upload prediction models to Azure Storage
 
-This repository contains the source code to train ML models for making label predictions, as well as the code for automatically applying issue labels onto issue/pull requests on GitHub repositories.
+If the label training model for your repo is out of date or non-existent, you will need to create a new model, upload it to Azure Storage, and update the predictor app to use the new model.
 
-This issue-labeler uses [ML.NET](https://github.com/dotnet/machinelearning) to help predict labels on github issues and pull requests. 
+Pre-requisites:
 
-## Table of Contents
+1. The repo must already have "area" labels that follow the pattern `area/some_name`, `area:some_name`, or `area-some_name`, and a minimum of 500 issues labeled with at least one area label. If there are too few labeled issues, the model will not be reliable. Also, areas are ideally exclusive, meaning that issues or PRs should have exactly one label. It's acceptable to have more than one area label on an item, but those are not reliable for generating models.
+1. To upload models to Azure, you must have access to the `GitHubIssueLabeller` resource group in the `DDFun IaaS Dev Shared Public` Azure Subscription. Contact the DevDiv Azure Ops email alias to request access.
 
-- Download/Train ML models
-- Pack ML models into nuget
-- Application setup: a step-by-step example
-  - Get top-N label predictions
-  - Enable automatic label assignments
+To get started, clone the https://github.com/dotnet/issue-labeler repo so that you can run the required tools.
 
-## How we Download/Train ML models
+1. Create training model on your machine
+   1. Open a command prompt in the `src/CreateMikLabelModel` folder of the issue-labeler repo
+   1. If you have not yet done so, create a GitHub OAuth token to use for this app:
+      1. Create a [GitHub Personal Access Token](https://github.com/settings/tokens) and copy the value to your clipboard
+      1. In the command prompt run: `dotnet user-secrets set GitHubAccessToken THE_TOKEN_VALUE`.
+   1. Run the tool for the repo you wish to use: `dotnet run -- owner/repo`, for example, `dotnet run -- dotnet/maui`
+      1. If you get an error that the repo is not listed, edit the `repos.json` file and add your repo. And then also send a PR to have the list updated in the issue labeler repo.
+      1. The tool will download all the GitHub issues and PRs from the repo. This can take anywhere from a few minutes to even 10 minutes, depending on how many issues/PRs exist in the repo.
+      1. It will then run a computationally intensive process to perform the machine learning. This can take around 30 minutes on a high-end workstation.
+      1. The output will be two ZIP files containing the models for issues and PRs. If the repo has no PRs, that model will be skipped.
+1. Upload model to Azure storage
+   1. Open a command prompt in the `src/DotNetLabelerUploader` folder of the issue-labeler repo
+   1. Get the Azure Storage access key for the `dotnetissuelabelerdata` storage account in Azure
+      1. In the Azure Portal, go to the DDFun IaaS Dev Shared Public subscription, and select the `dotnetissuelabelerdata` storage account
+      1. Select **Access keys** from the left side menu
+      1. Copy the Key value for key1 or key2.
+      1. In the command prompt run: `dotnet user-secrets set IssueLabelerKey AZURE_KEY_HERE`.
+   1. Run the tool for the repo data you wish to upload: `dotnet run -- C:\PATH\TO\ZIPS OWNER/REPO`, for example, `dotnet run -- C:\GitHub\issue-labeler\src\CreateMikLabelModel dotnet/maui`
+1. Update predictor app to point to the new model
+   1. The uploader tool from the previous step printed out further instructions how to do that. It looks something like this:
+      1. Go to https://portal.azure.com/
+      1. Go to this subscription: DDFun IaaS Dev Shared Public
+      1. Go to the appropriate App Service resource for this repo (see Web App Service List in this document)
+      1. Select Configuration
+      1. Set Application Setting `IssueModel:SOME_REPO:BlobName` to: `owner-repo-il-03.zip`
+      1. Set Application Setting `IssueModel:SOME_REPO:PathPrefix` to a new value, typically just incremented by one (the exact name doesn't matter)
+      1. Set Application Setting `PrModel:SOME_REPO:BlobName` to: `owner-repo-pr-03.zip`
+      1. Set Application Setting `PrModel:SOME_REPO:PathPrefix` to a new value, typically just incremented by one (the exact name doesn't matter; common pattern is to use `GHM-[ZIP_FILE_NAME_WITHOUT_EXTENSION]`, such as GHM-aspnetcore-issue-03)
+      1. Click Save and accept the confirmation, which will restart the application and start using the new values
+      1. Run the DotNetLabelerWakerUpper tool in this repo to re-load the new models and check that they are all working.
 
-We use GraphQL and [Octokit](https://www.nuget.org/packages/Octokit/) to download issues from GitHub and then train models using [ML.NET](ML.NET). e.g. dotnet/runtime repository has been trained on over 30,000 issues, and 5,000 PRs which have been labeled in the past, either manually or automatically.
+## Test prediction models and warm up the predictor apps
 
-#### About CreateMikLabel project
+Once the new model is uploaded, you'll need to warm up the predictor app and test that it is predicting labels for issues and PRs in that repo.
 
-The [CreateMikLabelModel](https://github.com/dotnet/issue-labeler/tree/master/src/CreateMikLabelModel) project is responsible for:
+1. Open a command prompt in the `src/DotNetLabelerWakerUpper` folder of the issue-labeler repo
+1. Run `dotnet run`
 
-1. Downloading Github issues and pull requests
-2. Specifying which data to download (title, description, labels, author, mentions, PR file names, optionally PR diff etc.)
-3. Segmenting issue or PR records into train (first 80%), validate (second 10%), and test (last 10%) data.
-4. Customizing ML training settings: ML models to skip/consider (e.g. FastTreeOva), time to train, information to consider while training (e.g. number of file changes).
-5. Optionally testing the ML generated Models to help understand which area labels may be getting more missed predictions or lower confidence compared to others.
+This will call the `load` API of each known labeler app, wait for it to be ready, and then get label predictions for arbitrary issues and PRs in that repo. This can take a few minutes to run.
 
-#### ML customization:
+Note: If you added a new repo, please edit the `src/DotNetLabelerWakerUpper/appSettings.json` file in the issue labeler repo and add two issues and two PRs to the list so that the waker-upper tool can warm up the predictions for the new repo as well.
 
-As seen in [commit](https://github.com/dotnet/issue-labeler/commit/77e4dbc45184f34e940c0f3cba57160e30c2c183), the [ExperimentModifier](https://github.com/maryamariyan/issue-labeler-2/blob/213a96cf88d31333295126e7815c4688c2e31b54/src/CreateMikLabelModel/ML/ExperimentModifier.cs) class in CreateMikLabelModel project helps configure how the models should be trained (what column information to use (e.g. issue Description), how to treat them (as Text, Categorical data, Numeric or Ignore), how long to let the experiment run, and which algorithms to let AutoML consider while training (FastTreeOva, LightGbm, etc.)).
+## Use predicted labels in your repo
 
-## [Archived] Pack ML models into nuget
+Once you have configured a predictor and uploaded a training model, there are three patterns for predicting labels in your repo:
 
-In the past we used to pack the resulting models into a nuget package called `Microsoft.DotNet.GitHubIssueLabeler.Assets` to be easily consumable within a web application. But now we have retired the nuget package and instead use Azure Blob Storage to upload the models for use in the application.
+1. Use a GitHub Webhook to automatically apply the best predicted area label to a new issue or PR
+1. Use Hubbup's MikLabel UI to view predicted labels and apply them
+1. Use an Edge/Chrome browser extension to view predicted labels and apply them
 
-#### About the `Microsoft.DotNet.GitHub.IssueLabeler` project
+### Setting up GitHub Webhooks for fully automated labeling
 
-The [Microsoft.DotNet.GitHub.IssueLabeler](https://github.com/dotnet/issue-labeler/tree/master/src/Microsoft.DotNet.GitHub.IssueLabeler) project is the web application that uses ML models created using CreateMikLabelModel to predict area labels. Given repository owner/name/number combination, the IssueLabeler app provides an API returning top three predictions along with their confidence score. This information is computed using the ML models loaded in memory uploaded from Azure Blob Storage, which we produced in CreateMikLabelerModel project.
-Since dotnet/runtime has a big set of area owners and contributors, we decided to use an automatic assignment for issues and PRs. In order to achieve automatic label assignments, the IssueLabeler app, listens to all issue and PR creations via a webhook setting and finds top three predictions and only when the top prediction score has above 40% confidence, then this labeler app is allowed to automatically add that area label name to the newly created issue or PR. For dotnet/aspnetcore however, this webhook is not active and instead, the aspnetcore repository uses the hubbup web app to allow for manual area label assignment. Rather than doing automatic assignments, the hubbup app provides a nice UI for the prediction results it receives from [Microsoft.DotNet.GitHub.IssueLabeler](https://github.com/dotnet/issue-labeler/tree/master/src/Microsoft.DotNet.GitHub.IssueLabeler).
+TODO: How to do this?
 
-#### About the public-dispatcher branch
+### Use Hubbup to view label predictions
 
-The public-dispatcher branch is the code base for the github app that gets installed per github organization. We would have one app instance per org (one for Microsoft and one for dotnet) based off the public-dispatcher branch. The github app would be able to query top three predictions in a distributed way from other app(s) based off of the main branch which are configured for one or more repository to provide prediction scores.
+TODO: Contact Eilon Lipton
 
-![image](https://user-images.githubusercontent.com/5897654/154319795-35975683-c4ae-477d-8a7c-74ad3079f1ed.png)
+### Use a browser extension to view label predictions
 
-Based on the above diagram we can publish multiple apps using the same source code from main branch, where each app is responsible for giving predictions for one or more github repositories. But there would be only a single github app per github organization (e.g. dotnet) which has the webhook setup to update issue/PRs with labels by referring to prediction results from the one or more ML-based apps configured.
+TODO: Contact Eilon Lipton
 
-## Application setup: a step-by-step example
+## Web App Service List
 
-### Prerequisites
+There are several Web App Services running, each configured for predictions for a set of repos. Note that a Web App Service can support multiple repos in the same GitHub org, but cannot support multiple orgs.
 
-* Create a [GitHub Personal Access Token](https://github.com/settings/tokens) that includes the `repo:public_repo` scope (to access public repositories)
-* Register that token on your machine by first navigating to the `src\CreateMikLabelModel` folder, which contains the project file needing `GitHubAccessToken`, then add the user secret with the command: `dotnet user-secrets set GitHubAccessToken "{{ghp_token_value}}"`. For more information refer to docs on enabling secret storage [here](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-6.0&tabs=windows#enable-secret-storage).
+If you are adding a new repo and the repo is in the same org as one of the repos below, consider adding your repo's data to an existing app (but ask the existing users for permission first!).
 
-### Execution
+* App: dotnet-aspnetcore-labeler
+  1. dotnet/aspnetcore issue+pr
+  1. dotnet/maui issue+pr
+  1. dotnet/roslyn issue+pr (not actually used!)
+* App: dotnet-roslyn-labeler
+  1. dotnet/roslyn issue+pr
+  1. dotnet/source-build issue
+* App: dotnet-runtime-issue-labeler
+  1. dotnet/docker-tools issues
+  1. dotnet/dotnet-api-docs issues+pr
+  1. dotnet/dotnet-buildtools-prereqs-docker issues
+  1. dotnet/dotnet-docker issues
+  1. dotnet/runtime issues+pr
+  1. dotnet/sdk issues+pr
+* App: microsoft-dotnet-framework-docker
+  1. microsoft/dotnet-framework-docker issues
+* App: nuget-home-labeler
+  1. nuget/home issues
 
-* Run the CreateMikLabelModel application using `dotnet run` from the `src\CreateMikLabelModel` folder
-* Specify the repo to be modeled as a command line argument: `dotnet run -- [repo]`
+## Further reading
 
-You can configure the web application to either give you the top 3 recommended labels or automatically assign the top choice.
+* [Implementation details](./Implementation.md) - more details on how certain projects in this repo work

--- a/README.md
+++ b/README.md
@@ -2,17 +2,23 @@
 
 This repo contains the code to build the dotnet issue labeler.
 
-## Which github repositories use this issue labeler today?
+## Intro to issue labeling
+
+This repository contains the source code to train ML models for making label predictions, as well as the code for automatically applying issue labels onto issue/pull requests on GitHub repositories.
+
+This issue-labeler uses [ML.NET](https://github.com/dotnet/machinelearning) to help predict labels on github issues and pull requests. 
+
+## Which GitHub repositories use this issue labeler today?
 
 The dotnet organization contains repositories with many incoming issues and pull requests. In order to help with the triage process, issues get categorized with area labels. The issues related to each area get labeled with a specific `area-` label, and then these label assignments get treated as learning data for an issue labeler to be built. 
 
-The following repositories currently triage their incoming issues semi-automatically, by manually selecting one of top 3 predictions received from a dotnet/issue-labeler:
+The following repositories triage their incoming issues semi-automatically, by manually selecting one of top 3 predictions received from a dotnet/issue-labeler:
 
 * [dotnet/aspnetcore](https://github.com/dotnet/aspnetcore)
 * [dotnet/extensions](https://github.com/dotnet/extensions)
 * [dotnet/maui](https://github.com/dotnet/maui)
 
-The following repositories allow dotnet/issue-labeler to automatically set `area-` labels for incoming issues and pull requests:
+The following repositories allow dotnet/issue-labeler to automatically set `area-` labels for incoming issues and pull requests using [GitHub Webhooks](https://docs.github.com/en/get-started/customizing-your-github-workflow/exploring-integrations/about-webhooks):
 
 * [dotnet/runtime](https://github.com/dotnet/runtime)
 * [dotnet/corefx](https://github.com/dotnet/corefx) (archived)
@@ -25,34 +31,26 @@ The following repositories allow dotnet/issue-labeler to automatically set `area
 * [dotnet/source-build](https://github.com/dotnet/source-build)
 * [microsoft/dotnet-framework-docker](https://github.com/microsoft/dotnet-framework-docker)
 
-Of course with automatic labeling there is always a margin of error. But the good thing is that the labeler can learns from mistakes so long as wrong label assignments get corrected manually.
+Of course with automatic labeling there is always a margin of error. But the good thing is that the labeler learns from mistakes so long as wrong label assignments get corrected manually.
 
-To help with this process, any new issue that gets created also takes an `untriaged` label which then is expected to get removed by area owner for the assigned area label as they go through their triage process. Once being reviewed by the area owner, if they deem the automatic label as incorrect they may remove incorrect label and allow for correct one to get added manually.
+For some repos, new issues get an `untriaged` label, which then is expected to get removed by the area owner for the assigned area label as they go through their triage process. Once reviewed by the area owner, if they deem the automatic label as incorrect they may remove incorrect label and allow for correct one to get added manually.
 
 ## How to use this issue labeler today?
 
-To get the most out of this issue labeler, prior setup, the repository needs to get to a point where it has been pre-populated with a portion of issues with `area-` labels on them. 
+Enabling the issue labeler for a repo entails these steps:
 
-It is possible to still get usage out of this issue labeler, even if you decided to continue doing manual label assignments, e.g. to get top-N predictions recommendations only.
+1. Manually apply `area-*` labels to a few hundred issues, which will be used as training data
+1. Generate machine learning training data and upload to an Azure Storage container
+1. Configure a new or existing Azure Web App with the issue labeler web app
+1. Update the issue labeler web app to use the training data
+1. Then either:
+   * Configure GitHub webhooks for fully automated label application
+   * Configure [Hubbup](https://hubbup.io/) to show predictions
+   * Use a browser extension to view predictions
 
-But once the issue labeling is automated, it is recommended to make sure:
+And then periodically re-train the machine learning data so that the model can learn from a larger dataset of issues that have correct area labels applied. Note: the system does not learn in real time!
 
-- Contributors have a habit of manually applying `area-` labels even when the labeler was not confident enough to select one.
-- Contributors have a habit of manually correcting prediction mistakes done.
-
-These two habits help the issue labeler learn better over time.
-
-Also note, the labeler does not learn in real-time, but instead ML trainings need to be redone every once in a while (e.g. every two months depending on issue traffic).
-
-## How to get started?
-
-The [docs](Documentation/) page explains in more detail steps involved in setting up an issue labeler for a github repository.
-
-## Useful Links
-
-* [ML.NET](ML.NET) 
-* [.NET home repo](https://github.com/Microsoft/dotnet) - links to 100s of .NET projects, from Microsoft and the community.
-* [ASP.NET Core home](https://docs.microsoft.com/aspnet/core/?view=aspnetcore-3.1) - the best place to start learning about ASP.NET Core.
+To get started, check out the [docs](Documentation/) for detailed steps to set up the issue labeler for your GitHub repo.
 
 ## License
 


### PR DESCRIPTION
Some of the existing docs were re-organized, and many new docs were added.

- The main readme has basic info
- The Documentation folder has a readme for how to set things up, and a secondary file with some implementation details

Some of the docs are still incomplete, but it's far more extensive than we had.