### PR TITLE
Allow configuration of a label to apply when no area label is determined

### DIFF
--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Microsoft.DotNet.Github.IssueLabeler.csproj
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Microsoft.DotNet.Github.IssueLabeler.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\eng\Versions.props" />
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>


### PR DESCRIPTION
Fixes #27

Allows configuration by repository for an optional label to apply when no area can be determined. When such a label is configured, that label is applied instead of adding a comment saying the issue/pr needs an area label. When no such label is configured, the comment is still added as it is today.

I've also retargeted from net5.0 to net7.0.

@maryamariyan or @Eilon -- This needs your confirmation that I'm reading the options correctly such that we can use Azure App Configuration to specify `{owner}:{repo}:no_area_determined_label` as a string and that will get loaded. And/or, I'll need help from @dakersnar to deploy and test this.
