### PR TITLE
Revert prior changes that led to service interruption

### DIFF
--- a/src/CreateMikLabelModel/CreateMikLabelModel.csproj
+++ b/src/CreateMikLabelModel/CreateMikLabelModel.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\eng\Versions.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UserSecretsId>AspNetHello.App</UserSecretsId>
   </PropertyGroup>

--- a/src/Hubbup.MikLabelModel/Hubbup.MikLabelModel.csproj
+++ b/src/Hubbup.MikLabelModel/Hubbup.MikLabelModel.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\eng\Versions.props" />
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Microsoft.DotNet.Github.IssueLabeler.csproj
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Microsoft.DotNet.Github.IssueLabeler.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\eng\Versions.props" />
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>


### PR DESCRIPTION
This PR reverts #53 as well as 0451a627ba0415cdf89de9097aa522c3e6c0ff94 (which was pushed without a PR). When the changes from that PR and the extra commit were deployed, the issue-labeler stopped functioning and all labeling halted across all repositories that are onboarded.

We restored the service by deploying the application from commit 7fc3de667187876a337513690224cab981052a90.

This PR returns the `feature/public-dispatcher` branch back to the state that is currently deployed. We will then build back on top of that base to attempt to move the branch forward with new behaviors while improving the testing of deployments to understand what caused the service to stop functioning before.