### PR TITLE
Add a test project with notes on how to test dispatcher deployments

### DIFF
--- a/issue-labeler.sln
+++ b/issue-labeler.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28902.138
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33502.453
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3D534DD7-7F6F-45D7-A62B-3E7DCF9FAB8F}"
 EndProject
@@ -16,6 +16,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hubbup.MikLabelModel", "src\Hubbup.MikLabelModel\Hubbup.MikLabelModel.csproj", "{CA47F6FC-382F-4034-9F12-517CC14E5CB0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Github.IssueLabeler", "src\Microsoft.DotNet.GitHub.IssueLabeler\Microsoft.DotNet.Github.IssueLabeler.csproj", "{AF671A89-AC9D-42C8-A940-73745684B63A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{EF4BDB98-1F19-48B2-A2BD-706C038CDE97}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeploymentTests", "test\DeploymentTests\DeploymentTests.csproj", "{7984BD2C-738F-4A0C-B5B1-4DDDCBFEDA8C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,6 +39,10 @@ Global
 		{AF671A89-AC9D-42C8-A940-73745684B63A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF671A89-AC9D-42C8-A940-73745684B63A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF671A89-AC9D-42C8-A940-73745684B63A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7984BD2C-738F-4A0C-B5B1-4DDDCBFEDA8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7984BD2C-738F-4A0C-B5B1-4DDDCBFEDA8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7984BD2C-738F-4A0C-B5B1-4DDDCBFEDA8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7984BD2C-738F-4A0C-B5B1-4DDDCBFEDA8C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -43,6 +51,7 @@ Global
 		{5966A77B-5114-4608-92AD-524F181FA0FC} = {3D534DD7-7F6F-45D7-A62B-3E7DCF9FAB8F}
 		{CA47F6FC-382F-4034-9F12-517CC14E5CB0} = {3D534DD7-7F6F-45D7-A62B-3E7DCF9FAB8F}
 		{AF671A89-AC9D-42C8-A940-73745684B63A} = {3D534DD7-7F6F-45D7-A62B-3E7DCF9FAB8F}
+		{7984BD2C-738F-4A0C-B5B1-4DDDCBFEDA8C} = {EF4BDB98-1F19-48B2-A2BD-706C038CDE97}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {60D53155-0C10-41E9-B797-FC68F4EDFF8A}

--- a/test/DeploymentTests/DeploymentTests.csproj
+++ b/test/DeploymentTests/DeploymentTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/test/DeploymentTests/IssueLabelingTests.cs
+++ b/test/DeploymentTests/IssueLabelingTests.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DeploymentTests;
+
+/// <summary>
+/// Executes tests against the issue labeling service to verify it's behaving as expected.
+/// </summary>
+/// <remarks>
+/// These tests invoke the issue labeler through the webhook endpoint, but they cannot validate the results
+/// of the app's labeling behavior since there's no output from the requests. To verify the behavior, the
+/// application service logs must be reviewed after running these tests to ensure the expected results occurred.
+/// <para>
+/// The tests use a custom User-Agent that shows up in the HTTP request/response Application logs. The User-Agent
+/// is in the format of `DeploymentTests/yyyyMMdd.HHmmss+(IssueLabelingTests;{test-name})`.
+/// </para>
+/// <para>
+/// Preparation steps for seeing the basic HTTP request/response Application logs:
+/// 1. Log into the Azure portal: https://portal.azure.com
+/// 2. Navigate to the deployed application (e.g. 'dispatcher-app')
+/// 3. Wait for everything on the left-nav to load
+/// 4. Within the Monitoring section, open 'App Service logs'
+/// 5. Ensure 'Application logging (Filesystem)' is enabled. This setting turns itself off after 12 hours.
+/// 6. Set the Application logging 'Level' to 'Information'
+/// 7. Save changes if needed.
+/// 8. Within the Monitoring section, open 'Log stream'
+/// 9. Verify that the log stream indicates that you are now connected to the log-streaming service.
+/// 
+/// Once the above preparation is completed, proceed with running these tests. Each test has a comment for how
+/// to validate that the expected behavior occurred. Note that the Log stream has a delay to it and it can take
+/// as much as 2 minutes between the time a test is invoked and its corresponding logs are visible in the stream.
+/// </para>
+/// <para>
+/// Preparation steps for seeing the application logger information that shows the background worker logs:
+/// 1. From the deployed application in the Azure portal, within the 'Development Tools' section, open 'App Service Editor (Preview)'
+/// 2. Click the 'Open Editor' link to open the App Service Editor
+/// 3. Open the `web.config` file (e.g. https://dispatcher-app.scm.azurewebsites.net/dev/wwwroot/web.config)
+/// 4. Change `stdoutLogEnabled` to "true"
+/// 5. On the Azure portal 'Overview' page for the application, Restart the application
+/// 6. Under the 'Development Tools' section, go to 'Advanced Tools' and click 'Go'
+/// 7. From the top-nav, open a 'Debug Console' (either CMD or PowerShell)
+/// 8. Navigate into the 'LogFiles' folder
+/// 9. Find the most recent file named 'stdout_yyyyMMddHHmmss_x.log', and copy the URL from its download icon
+/// 
+/// Here's a PowerShell command to get the most recent 5 stdout_*.log files:
+///     ls stdout*.log | sort LastWriteTime -Descending | Select -First 5
+/// 
+/// Given the URL of the most recent log, you can download the current log file. The file will be written to repeatedly as more
+/// logs accumulate. Log data is flushed to disk periodically; you can force the log to be flushed by restarting the service.
+/// </para>
+/// </remarks>
+public class IssueLabelingTests : ServiceTestBase
+{
+    public IssueLabelingTests() : base(nameof(IssueLabelingTests)) { }
+
+    public enum IssueOrPullRequest
+    {
+        Issue,
+        PullRequest
+    }
+
+    /// <summary>
+    /// Produces a log result of:
+    /// GET /api/webhookissue/test/{org}/{repo}/{id}
+    /// </summary>
+    [Theory]
+    [InlineData("dotnet", "runtime", 42_000)]
+    public async Task GET_test_endpoint(string org, string repo, int id)
+    {
+        HttpResponseMessage? response = await CreateTestHttpClient().GetAsync(new Uri(ServiceTestBase.ServiceWebhookApiRoot, $"test/{org}/{repo}/{id}"));
+        Assert.True(response.IsSuccessStatusCode);
+    }
+
+    /// <summary>
+    /// Produces a log entry in the Application logs and starts a background worker that will yield entries in the stdout log.
+    /// </summary>
+    /// <remarks>
+    /// Application Logs:
+    /// POST /api/webhookissue/ ... 443 ... DeploymentTests/yyyyMMdd.HHmmss+(IssueLabelingTests;POST_webhook_endpoint)
+    /// <para>
+    /// Stdout Logs:
+    /// Log entries will be created tracking the results of receiving a webhook event for the issues/prs. These log entries
+    /// can be helpful for troubleshooting behavior of the Labeler and/or verifying that the expected results occurred.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("dotnet", "runtime", IssueOrPullRequest.Issue, 42000)]
+    [InlineData("dotnet", "roslyn", IssueOrPullRequest.PullRequest, 42000)]
+    [InlineData("dotnet", "aspnetcore", IssueOrPullRequest.Issue, 42000)]
+    public async Task POST_webhook_endpoint(string org, string repo, IssueOrPullRequest type, int id)
+    {
+        string issueOrPullRequest = type switch
+        {
+            IssueOrPullRequest.Issue => "issue",
+            IssueOrPullRequest.PullRequest => "pull_request",
+            _ => throw new ArgumentException(nameof(type)),
+        };
+
+        StringContent requestContent = new StringContent($$"""
+            {
+                "action": "opened",
+                "{{issueOrPullRequest}}": {
+                    "number": {{id}}
+                },
+                "repository": {
+                    "full_name": "{{org}}/{{repo}}"
+                }
+            }
+            """, Encoding.UTF8, "application/json");
+
+        HttpResponseMessage? response = await CreateTestHttpClient().PostAsync(ServiceTestBase.ServiceWebhookApiRoot, requestContent);
+
+        Assert.True(response.IsSuccessStatusCode);
+    }
+}

--- a/test/DeploymentTests/ServiceAvailabilityTests.cs
+++ b/test/DeploymentTests/ServiceAvailabilityTests.cs
@@ -1,0 +1,21 @@
+namespace DeploymentTests
+{
+    public class ServiceAvailabilityTests : ServiceTestBase
+    {
+        public ServiceAvailabilityTests() : base(nameof(ServiceAvailabilityTests)) { }
+
+        [Fact]
+        public async Task RootUrlResponds()
+        {
+            string response = await CreateTestHttpClient().GetStringAsync(ServiceTestBase.ServiceRoot);
+            Assert.Equal("Check the logs, or predict labels.", response);
+        }
+
+        [Fact]
+        public async Task WebhookApiRootResponds()
+        {
+            string response = await CreateTestHttpClient().GetStringAsync(ServiceTestBase.ServiceWebhookApiRoot);
+            Assert.Equal("Check the logs, or predict labels.", response);
+        }
+    }
+}

--- a/test/DeploymentTests/ServiceTestBase.cs
+++ b/test/DeploymentTests/ServiceTestBase.cs
@@ -1,0 +1,32 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace DeploymentTests;
+
+public abstract class ServiceTestBase
+{
+    public static Uri ServiceRoot = new Uri("https://dispatcher-app.azurewebsites.net/");
+    public static Uri ServiceWebhookApiRoot = new Uri(ServiceRoot, "/api/webhookissue/");
+
+    private readonly string _nameofTestClass;
+
+    protected ServiceTestBase(string nameOfTestClass) => _nameofTestClass = nameOfTestClass;
+
+    protected HttpClient CreateTestHttpClient([CallerMemberName] string? nameofTestMethod = null)
+    {
+        string[] userAgentParts = new[] { _nameofTestClass, nameofTestMethod } switch
+        {
+            [null, null] => new string[] { },
+            [string className, null] => new[] { className },
+            [null, string testName] => new[] { testName },
+            [string className, string testName] => new[] { className, testName },
+            _ => throw new ArgumentException(),
+        };
+
+        string userAgent = $"DeploymentTests/{DateTime.Now.ToString("yyyyMMdd.HHmmss")} ({string.Join(';', userAgentParts)})";
+
+        HttpClient testClient = new HttpClient();
+        testClient.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
+
+        return testClient;
+    }
+}

--- a/test/DeploymentTests/Usings.cs
+++ b/test/DeploymentTests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
It is _waaaaayyyyy_ too complicated to be able to monitor the behavior of the dispatcher app, but this is what we have at the moment. With these tests and instructions, I've been able to verify that we can see both real and simulated webhook api events.

These tests are to be run manually/locally before and after a deployment to ensure the service continues to function as expected.