### PR TITLE
Enable stdout logging in deployment

### DIFF
--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/web.config
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/web.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <system.webServer>
+    <handlers>
+      <remove name="aspNetCore"/>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath="%LAUNCHER_PATH%"
+                arguments="%LAUNCHER_ARGS%"
+                stdoutLogEnabled="true"
+                stdoutLogFile="%HOME%\LogFiles\stdout"
+                hostingModel="inprocess" />
+  </system.webServer>  
+
+</configuration>


### PR DESCRIPTION
Fixes #58

I've deployed the service with this change in place and verified that stdout logging was enabled with the deployment. And I saw the expected effects on the deployed web.config file.

```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <system.webServer>
    <handlers>
      <remove name="aspNetCore" />
      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
    </handlers>
    <aspNetCore processPath=".\Microsoft.DotNet.Github.IssueLabeler.exe" arguments="" stdoutLogEnabled="true" stdoutLogFile="\\?\%home%\LogFiles\stdout" hostingModel="inprocess" />
  </system.webServer>
</configuration>
```

After deployment, I also ran the tests included from #57 and saw the expected results in the stdout logs. Another piece of evidence that the deployment is working as expected is [dotnet/aspnetcore#30000](https://github.com/dotnet/aspnetcore/issues/30000#event-8773238958), where the app is now applying the `untriaged` label to issues in that repository. I removed the label, ran the tests, and the app reapplied the label.