### PR TITLE
Do no apply the untriaged label to the aspnetcore repo

### DIFF
--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.DotNet.GitHub.IssueLabeler;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.DotNet.Github.IssueLabeler.Models
 {
@@ -8,9 +9,8 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
     {
         public bool AddDelayBeforeUpdatingLabels { get => _repo.Equals("dotnet-api-docs", StringComparison.OrdinalIgnoreCase); }
 
-        public bool OkToAddUntriagedLabel { get =>
-                !_repo.Equals("runtime", StringComparison.OrdinalIgnoreCase) &&
-                !_repo.Equals("dotnet-api-docs", StringComparison.OrdinalIgnoreCase); }
+        private readonly IEnumerable<string> _untriagedLabelDisabledRepos = new string[] { "runtime", "aspnetcore", "dotnet-api-docs" };
+        public bool OkToAddUntriagedLabel { get => !_untriagedLabelDisabledRepos.Contains(_repo, StringComparer.OrdinalIgnoreCase); }
 
         public bool CommentWhenMissingAreaLabel { get => !_repo.Equals("deployment-tools", StringComparison.OrdinalIgnoreCase); }
         public bool SkipPrediction { get => 


### PR DESCRIPTION
Fixes #56 

Here's the low-touch implementation of this, @mkArtakMSFT. I'm going to follow up with a separate PR that moves a lot of hard-coded repo options into configuration.

This is already deployed and I tested it by running the tests introduced in #57 and verified that with this change, the tests no longer add the `untriaged` label to [dotnet/aspnetcore#30000](https://github.com/dotnet/aspnetcore/issues/30000#event-8773432689).