### PR TITLE
Use configuration instead of hard-coded settings

### DIFF
--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Microsoft.DotNet.Github.IssueLabeler.csproj
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Microsoft.DotNet.Github.IssueLabeler.csproj
@@ -6,6 +6,7 @@
     <SignAssembly>false</SignAssembly>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
@@ -43,10 +43,14 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
                 @"https://github.com/dotnet/runtime/blob/master/docs/area-owners.md" +
             ")" : "area label";
 
-        public string MessageToAddAreaLabelForPr =>
-            "I couldn't figure out the best area label to add to this PR. If you have write-permissions please help me learn by adding exactly one " + _areaLabelLinked + ".";
-        public string MessageToAddAreaLabelForIssue =>
-            "I couldn't figure out the best area label to add to this issue. If you have write-permissions please help me learn by adding exactly one " + _areaLabelLinked + ".";
+        private static string LinkToAreaOwnersDoc(string areaOwnersDoc) =>
+            string.IsNullOrWhiteSpace(areaOwnersDoc) ? "area label" : $"[area label]({areaOwnersDoc})";
+
+        public string GetMessageToAddAreaLabelForPr(string areaOwnersDoc) =>
+            $"I couldn't figure out the best area label to add to this PR. If you have write-permissions please help me learn by adding exactly one {LinkToAreaOwnersDoc(areaOwnersDoc)}.";
+
+        public string GetMessageToAddAreaLabelForIssue(string areaOwnersDoc) =>
+            $"I couldn't figure out the best area label to add to this issue. If you have write-permissions please help me learn by adding exactly one {LinkToAreaOwnersDoc(areaOwnersDoc)}.";
 
         private readonly string _owner;
         private readonly string _repo;

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
@@ -20,16 +20,6 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
             return false;
         }
 
-        public bool OkToIgnoreThresholdFor(string chosenLabel)
-        {
-            if (_owner.Equals("dotnet", StringComparison.OrdinalIgnoreCase) && _repo.Equals("runtime", StringComparison.OrdinalIgnoreCase))
-            {
-                // return (!chosenLabel.Equals("area-System.Net", StringComparison.OrdinalIgnoreCase) && 
-                //     chosenLabel.StartsWith("area-System", StringComparison.OrdinalIgnoreCase));
-            }
-            return false;
-        }
-
         public string GetMessageToAddDocForNewApi(string label) => $"""
             Note regarding the `{label}` label:
 

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
@@ -7,8 +7,6 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
 {
     public class LabelRetriever
     {
-        public bool CommentWhenMissingAreaLabel { get => !_repo.Equals("deployment-tools", StringComparison.OrdinalIgnoreCase); }
-
         public bool PreferManualLabelingFor(string chosenLabel)
         {
             if (_owner.Equals("dotnet", StringComparison.OrdinalIgnoreCase) && _repo.Equals("runtime", StringComparison.OrdinalIgnoreCase))
@@ -23,11 +21,6 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
 
             This serves as a reminder for when your PR is modifying a ref *.cs file and adding/modifying public APIs, to please make sure the API implementation in the src *.cs file is documented with triple slash comments, so the PR reviewers can sign off that change.
             """;
-
-        private string _areaLabelLinked =>
-            _repo.Equals("runtime", StringComparison.OrdinalIgnoreCase) ? "[area label](" +
-                @"https://github.com/dotnet/runtime/blob/master/docs/area-owners.md" +
-            ")" : "area label";
 
         private static string LinkToAreaOwnersDoc(string areaOwnersDoc) =>
             string.IsNullOrWhiteSpace(areaOwnersDoc) ? "area label" : $"[area label]({areaOwnersDoc})";

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.DotNet.GitHub.IssueLabeler;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.DotNet.Github.IssueLabeler.Models
 {
@@ -19,7 +18,7 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
         public string GetMessageToAddDocForNewApi(string label) => $"""
             Note regarding the `{label}` label:
 
-            This serves as a reminder for when your PR is modifying a ref *.cs file and adding/modifying public APIs, to please make sure the API implementation in the src *.cs file is documented with triple slash comments, so the PR reviewers can sign off that change.
+            This serves as a reminder for when your PR is modifying a ref *.cs file and adding/modifying public APIs, please make sure the API implementation in the src *.cs file is documented with triple slash comments, so the PR reviewers can sign off that change.
             """;
 
         private static string LinkToAreaOwnersDoc(string areaOwnersDoc) =>

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
@@ -13,14 +13,6 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
         public bool SkipPrediction { get => 
                 _repo.Equals("deployment-tools", StringComparison.OrdinalIgnoreCase); }
 
-        public bool AllowTakingLinkedIssueLabel
-        {
-            get =>
-            (_owner.Equals("dotnet", StringComparison.OrdinalIgnoreCase) && _repo.Equals("runtime", StringComparison.OrdinalIgnoreCase)) ||
-            (_owner.Equals("dotnet", StringComparison.OrdinalIgnoreCase) && _repo.Equals("sdk", StringComparison.OrdinalIgnoreCase)) ||
-            (_owner.Equals("dotnet", StringComparison.OrdinalIgnoreCase) && _repo.Equals("dotnet-api-docs", StringComparison.OrdinalIgnoreCase));
-        }
-
         public bool PreferManualLabelingFor(string chosenLabel)
         {
             if (_owner.Equals("dotnet", StringComparison.OrdinalIgnoreCase) && _repo.Equals("runtime", StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
@@ -10,8 +10,6 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
         public bool AddDelayBeforeUpdatingLabels { get => _repo.Equals("dotnet-api-docs", StringComparison.OrdinalIgnoreCase); }
 
         public bool CommentWhenMissingAreaLabel { get => !_repo.Equals("deployment-tools", StringComparison.OrdinalIgnoreCase); }
-        public bool SkipPrediction { get => 
-                _repo.Equals("deployment-tools", StringComparison.OrdinalIgnoreCase); }
 
         public bool PreferManualLabelingFor(string chosenLabel)
         {
@@ -58,13 +56,6 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
         {
             _owner = owner;
             _repo = repo;
-        }
-
-        public bool ShouldSkipUpdatingLabels(string issueAuthor)
-        {
-            return _repo.Equals("roslyn", StringComparison.OrdinalIgnoreCase) &&
-                _owner.Equals("dotnet", StringComparison.OrdinalIgnoreCase) &&
-                issueAuthor.Equals("dotnet-bot", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
@@ -7,8 +7,6 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
 {
     public class LabelRetriever
     {
-        public bool AddDelayBeforeUpdatingLabels { get => _repo.Equals("dotnet-api-docs", StringComparison.OrdinalIgnoreCase); }
-
         public bool CommentWhenMissingAreaLabel { get => !_repo.Equals("deployment-tools", StringComparison.OrdinalIgnoreCase); }
 
         public bool PreferManualLabelingFor(string chosenLabel)

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/LabelRetriever.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.DotNet.GitHub.IssueLabeler;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.DotNet.Github.IssueLabeler.Models
 {
@@ -8,9 +9,8 @@ namespace Microsoft.DotNet.Github.IssueLabeler.Models
     {
         public bool AddDelayBeforeUpdatingLabels { get => _repo.Equals("dotnet-api-docs", StringComparison.OrdinalIgnoreCase); }
 
-        public bool OkToAddUntriagedLabel { get =>
-                !_repo.Equals("runtime", StringComparison.OrdinalIgnoreCase) &&
-                !_repo.Equals("dotnet-api-docs", StringComparison.OrdinalIgnoreCase); }
+        private readonly IEnumerable<string> _untriagedLabelDisabledRepos = new string[] { "runtime", "aspnetcore", "dotnet-api-docs" };
+        public bool OkToAddUntriagedLabel { get => !_untriagedLabelDisabledRepos.Contains(_repo, StringComparer.OrdinalIgnoreCase); }
 
         public bool CommentWhenMissingAreaLabel { get => !_repo.Equals("deployment-tools", StringComparison.OrdinalIgnoreCase); }
         public bool SkipPrediction { get => 

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
@@ -334,8 +334,15 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
 
             if (iopModel is PrModel pr)
             {
-                if (!string.IsNullOrWhiteSpace(options.NewApiPrLabel) && pr.ShouldAddDoc) nonAreaLabelsToAdd.Add(options.NewApiPrLabel);
-                if (pr.Author.Equals("monojenkins")) nonAreaLabelsToAdd.Add("mono-mirror");
+                if (!string.IsNullOrWhiteSpace(options.NewApiPrLabel) && pr.ShouldAddDoc)
+                {
+                    nonAreaLabelsToAdd.Add(options.NewApiPrLabel);
+                }
+
+                if (pr.Author.Equals("monojenkins"))
+                {
+                    nonAreaLabelsToAdd.Add("mono-mirror");
+                }
             }
 
             if (iopModel is IssueModel issue)

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
@@ -82,6 +82,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                         AreaOwnersDoc = _configuration.GetSection($"{owner}:{repo}:area_owners_doc").Get<string>(),
                         NewApiPrLabel = _configuration.GetSection($"{owner}:{repo}:new_api_pr_label").Get<string>(),
                         ApplyLinkedIssueAreaLabelToPr = _configuration.GetSection($"{owner}:{repo}:apply_linked_issue_area_label_to_pr").Get<bool>(),
+                        SkipLabelingForAuthor = (string author) => _configuration.GetSection($"{owner}:{repo}:skip_labeling_for_author:{author}").Get<bool>(),
                         SkipPrediction = _configuration.GetSection($"{owner}:{repo}:skip_prediction").Get<bool>(),
                         SkipUntriagedLabel = _configuration.GetSection($"{owner}:{repo}:skip_untriaged_label").Get<bool>(),
                     });
@@ -104,6 +105,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             public bool CanUpdateIssue { get; init; }
             public string NewApiPrLabel { get; init; }
             public bool ApplyLinkedIssueAreaLabelToPr { get; init; }
+            public Func<string, bool> SkipLabelingForAuthor { get; init; }
             public bool SkipPrediction { get; init; }
             public bool SkipUntriagedLabel { get; init; }
         }
@@ -124,9 +126,9 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             var labels = new HashSet<string>();
             GithubObjectType issueOrPr = iop.PullRequest != null ? GithubObjectType.PullRequest : GithubObjectType.Issue;
 
-            if (labelRetriever.ShouldSkipUpdatingLabels(iop.User.Login))
+            if (options.SkipLabelingForAuthor(iop.User.Login))
             {
-                _logger.LogInformation($"! dispatcher app - skipped for racing for {issueOrPr} {number}.");
+                _logger.LogInformation($"! dispatcher app - skipped labeling for author '{iop.User.Location}' on {owner}/{repo} {issueOrPr} {number}.");
                 return;
             }
 

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
@@ -79,6 +79,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                         Threshold = double.Parse(_configuration[$"{owner}:{repo}:threshold"]),
                         CanUpdateIssue = _configuration.GetSection($"{owner}:{repo}:can_update_labels").Get<bool>(),
                         CanCommentOnIssue = _configuration.GetSection($"{owner}:{repo}:can_comment_on").Get<bool>(),
+                        AreaOwnersDoc = _configuration.GetSection($"{owner}:{repo}:area_owners_doc").Get<string>(),
                         NewApiPrLabel = _configuration.GetSection($"{owner}:{repo}:new_api_pr_label").Get<string>(),
                         ApplyLinkedIssueAreaLabelToPr = _configuration.GetSection($"{owner}:{repo}:apply_linked_issue_area_label_to_pr").Get<bool>(),
                         SkipUntriagedLabel = _configuration.GetSection($"{owner}:{repo}:skip_untriaged_label").Get<bool>(),
@@ -97,6 +98,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             public LabelRetriever LabelRetriever { get; init; }
             public string PredictionUrl { get; init; }
             public double Threshold { get; init; }
+            public string AreaOwnersDoc { get; init; }
             public bool CanCommentOnIssue { get; init; }
             public bool CanUpdateIssue { get; init; }
             public string NewApiPrLabel { get; init; }
@@ -242,11 +244,11 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                 {
                     if (issueOrPr == GithubObjectType.Issue)
                     {
-                        await _gitHubClientWrapper.CommentOn(owner, repo, iop.Number, labelRetriever.MessageToAddAreaLabelForIssue);
+                        await _gitHubClientWrapper.CommentOn(owner, repo, iop.Number, labelRetriever.GetMessageToAddAreaLabelForIssue(options.AreaOwnersDoc));
                     }
                     else
                     {
-                        await _gitHubClientWrapper.CommentOn(owner, repo, iop.Number, labelRetriever.MessageToAddAreaLabelForPr);
+                        await _gitHubClientWrapper.CommentOn(owner, repo, iop.Number, labelRetriever.GetMessageToAddAreaLabelForPr(options.AreaOwnersDoc));
                     }
                 }
             }

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
@@ -82,6 +82,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                         AreaOwnersDoc = _configuration.GetSection($"{owner}:{repo}:area_owners_doc").Get<string>(),
                         NewApiPrLabel = _configuration.GetSection($"{owner}:{repo}:new_api_pr_label").Get<string>(),
                         ApplyLinkedIssueAreaLabelToPr = _configuration.GetSection($"{owner}:{repo}:apply_linked_issue_area_label_to_pr").Get<bool>(),
+                        SkipPrediction = _configuration.GetSection($"{owner}:{repo}:skip_prediction").Get<bool>(),
                         SkipUntriagedLabel = _configuration.GetSection($"{owner}:{repo}:skip_untriaged_label").Get<bool>(),
                     });
             }
@@ -103,6 +104,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             public bool CanUpdateIssue { get; init; }
             public string NewApiPrLabel { get; init; }
             public bool ApplyLinkedIssueAreaLabelToPr { get; init; }
+            public bool SkipPrediction { get; init; }
             public bool SkipUntriagedLabel { get; init; }
         }
 
@@ -133,7 +135,8 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
 
             bool foundArea = false;
             string theFoundLabel = default;
-            if (!labelRetriever.SkipPrediction)
+
+            if (!options.SkipPrediction)
             {
                 // find shortcut to get label
                 if (iop.PullRequest != null)

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
@@ -83,6 +83,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                         NewApiPrLabel = _configuration.GetValue<string>($"{owner}:{repo}:new_api_pr_label", null),
                         ApplyLinkedIssueAreaLabelToPr = _configuration.GetValue<bool>($"{owner}:{repo}:apply_linked_issue_area_label_to_pr", false),
 
+                        DelayLabelingSeconds = _configuration.GetValue<int>($"{owner}:{repo}:delay_labeling_seconds", 0),
                         SkipLabelingForAuthor = (string author) => _configuration.GetValue<bool>($"{owner}:{repo}:skip_labeling_for_author:{author}", false),
                         SkipPrediction = _configuration.GetValue<bool>($"{owner}:{repo}:skip_prediction", false),
                         SkipUntriagedLabel = _configuration.GetValue<bool>($"{owner}:{repo}:skip_untriaged_label", false),
@@ -106,6 +107,8 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             public bool CanUpdateLabels { get; init; }
             public string NewApiPrLabel { get; init; }
             public bool ApplyLinkedIssueAreaLabelToPr { get; init; }
+
+            public int DelayLabelingSeconds { get; init; }
             public Func<string, bool> SkipLabelingForAuthor { get; init; }
             public bool SkipPrediction { get; init; }
             public bool SkipUntriagedLabel { get; init; }
@@ -195,11 +198,10 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             GithubObjectType issueOrPr,
             LabelRetriever labelRetriever)
         {
-
-            if (labelRetriever.AddDelayBeforeUpdatingLabels)
+            if (options.DelayLabelingSeconds > 0)
             {
                 // to avoid race with dotnet-bot
-                await Task.Delay(TimeSpan.FromSeconds(10));
+                await Task.Delay(TimeSpan.FromSeconds(options.DelayLabelingSeconds));
             }
 
             // get iop again

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
@@ -79,9 +79,11 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                         Threshold = double.Parse(_configuration[$"{owner}:{repo}:threshold"]),
                         CanUpdateLabels = _configuration.GetValue<bool>($"{owner}:{repo}:can_update_labels", false),
                         CanCommentOnIssue = _configuration.GetValue<bool>($"{owner}:{repo}:can_comment_on", false),
+
                         AreaOwnersDoc = _configuration.GetValue<string>($"{owner}:{repo}:area_owners_doc", null),
                         NewApiPrLabel = _configuration.GetValue<string>($"{owner}:{repo}:new_api_pr_label", null),
                         ApplyLinkedIssueAreaLabelToPr = _configuration.GetValue<bool>($"{owner}:{repo}:apply_linked_issue_area_label_to_pr", false),
+                        NoAreaDeterminedSkipComment = _configuration.GetValue<bool>($"{owner}:{repo}:no_area_determined:skip_comment", false),
 
                         DelayLabelingSeconds = _configuration.GetValue<int>($"{owner}:{repo}:delay_labeling_seconds", 0),
                         SkipLabelingForAuthor = (string author) => _configuration.GetValue<bool>($"{owner}:{repo}:skip_labeling_for_author:{author}", false),
@@ -102,11 +104,13 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             public LabelRetriever LabelRetriever { get; init; }
             public string PredictionUrl { get; init; }
             public double Threshold { get; init; }
-            public string AreaOwnersDoc { get; init; }
             public bool CanCommentOnIssue { get; init; }
             public bool CanUpdateLabels { get; init; }
+
+            public string AreaOwnersDoc { get; init; }
             public string NewApiPrLabel { get; init; }
             public bool ApplyLinkedIssueAreaLabelToPr { get; init; }
+            public bool NoAreaDeterminedSkipComment { get; init; }
 
             public int DelayLabelingSeconds { get; init; }
             public Func<string, bool> SkipLabelingForAuthor { get; init; }
@@ -248,7 +252,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                 }
 
                 // if newlabels has no area-label and existing does not also. then comment
-                if (!foundArea && issueMissingAreaLabel && labelRetriever.CommentWhenMissingAreaLabel)
+                if (!foundArea && issueMissingAreaLabel && !options.NoAreaDeterminedSkipComment)
                 {
                     if (issueOrPr == GithubObjectType.Issue)
                     {

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                     {
                         _logger.LogInformation($"#  dispatcher app - skipped: prefer manual prediction instead.");
                     }
-                    else if (topChoice.Score >= options.Threshold || labelRetriever.OkToIgnoreThresholdFor(topChoice.LabelName))
+                    else if (topChoice.Score >= options.Threshold)
                     {
                         foundArea = true;
                         theFoundLabel = topChoice.LabelName;

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
@@ -80,6 +80,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                         CanUpdateIssue = _configuration.GetSection($"{owner}:{repo}:can_update_labels").Get<bool>(),
                         CanCommentOnIssue = _configuration.GetSection($"{owner}:{repo}:can_comment_on").Get<bool>(),
                         NewApiPrLabel = _configuration.GetSection($"{owner}:{repo}:new_api_pr_label").Get<string>(),
+                        ApplyLinkedIssueAreaLabelToPr = _configuration.GetSection($"{owner}:{repo}:apply_linked_issue_area_label_to_pr").Get<bool>(),
                         SkipUntriagedLabel = _configuration.GetSection($"{owner}:{repo}:skip_untriaged_label").Get<bool>(),
                     });
             }
@@ -93,13 +94,14 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
 
         private class LabelerOptions
         {
-            public LabelRetriever LabelRetriever { get; set; }
-            public string PredictionUrl { get; set; }
-            public double Threshold { get; set; }
-            public bool CanCommentOnIssue { get; set; }
-            public bool CanUpdateIssue { get; set; }
-            public string NewApiPrLabel { get; set; }
-            public bool SkipUntriagedLabel { get; set; }
+            public LabelRetriever LabelRetriever { get; init; }
+            public string PredictionUrl { get; init; }
+            public double Threshold { get; init; }
+            public bool CanCommentOnIssue { get; init; }
+            public bool CanUpdateIssue { get; init; }
+            public string NewApiPrLabel { get; init; }
+            public bool ApplyLinkedIssueAreaLabelToPr { get; init; }
+            public bool SkipUntriagedLabel { get; init; }
         }
 
         private async Task InnerTask(string owner, string repo, int number)
@@ -135,7 +137,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                 if (iop.PullRequest != null)
                 {
                     string body = iop.Body ?? string.Empty;
-                    if (labelRetriever.AllowTakingLinkedIssueLabel)
+                    if (options.ApplyLinkedIssueAreaLabelToPr)
                     {
                         (string label, int number) linkedIssue = await GetAnyLinkedIssueLabel(owner, repo, body);
                         if (!string.IsNullOrEmpty(linkedIssue.label))

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
@@ -77,14 +77,15 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                             "{0}/api/WebhookIssue/{1}/{2}/", _configuration[$"{owner}:{repo}:prediction_url"],
                             owner, repo),
                         Threshold = double.Parse(_configuration[$"{owner}:{repo}:threshold"]),
-                        CanUpdateIssue = _configuration.GetSection($"{owner}:{repo}:can_update_labels").Get<bool>(),
-                        CanCommentOnIssue = _configuration.GetSection($"{owner}:{repo}:can_comment_on").Get<bool>(),
-                        AreaOwnersDoc = _configuration.GetSection($"{owner}:{repo}:area_owners_doc").Get<string>(),
-                        NewApiPrLabel = _configuration.GetSection($"{owner}:{repo}:new_api_pr_label").Get<string>(),
-                        ApplyLinkedIssueAreaLabelToPr = _configuration.GetSection($"{owner}:{repo}:apply_linked_issue_area_label_to_pr").Get<bool>(),
-                        SkipLabelingForAuthor = (string author) => _configuration.GetSection($"{owner}:{repo}:skip_labeling_for_author:{author}").Get<bool>(),
-                        SkipPrediction = _configuration.GetSection($"{owner}:{repo}:skip_prediction").Get<bool>(),
-                        SkipUntriagedLabel = _configuration.GetSection($"{owner}:{repo}:skip_untriaged_label").Get<bool>(),
+                        CanUpdateLabels = _configuration.GetValue<bool>($"{owner}:{repo}:can_update_labels", false),
+                        CanCommentOnIssue = _configuration.GetValue<bool>($"{owner}:{repo}:can_comment_on", false),
+                        AreaOwnersDoc = _configuration.GetValue<string>($"{owner}:{repo}:area_owners_doc", null),
+                        NewApiPrLabel = _configuration.GetValue<string>($"{owner}:{repo}:new_api_pr_label", null),
+                        ApplyLinkedIssueAreaLabelToPr = _configuration.GetValue<bool>($"{owner}:{repo}:apply_linked_issue_area_label_to_pr", false),
+
+                        SkipLabelingForAuthor = (string author) => _configuration.GetValue<bool>($"{owner}:{repo}:skip_labeling_for_author:{author}", false),
+                        SkipPrediction = _configuration.GetValue<bool>($"{owner}:{repo}:skip_prediction", false),
+                        SkipUntriagedLabel = _configuration.GetValue<bool>($"{owner}:{repo}:skip_untriaged_label", false),
                     });
             }
             catch (Exception)
@@ -102,7 +103,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             public double Threshold { get; init; }
             public string AreaOwnersDoc { get; init; }
             public bool CanCommentOnIssue { get; init; }
-            public bool CanUpdateIssue { get; init; }
+            public bool CanUpdateLabels { get; init; }
             public string NewApiPrLabel { get; init; }
             public bool ApplyLinkedIssueAreaLabelToPr { get; init; }
             public Func<string, bool> SkipLabelingForAuthor { get; init; }
@@ -221,11 +222,11 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
 
                 labelsToAdd.AddRange(labels);
 
-                if (options.CanUpdateIssue && labelsToAdd.Any())
+                if (options.CanUpdateLabels && labelsToAdd.Any())
                 {
                     await _gitHubClientWrapper.AddLabels(owner, repo, number, labelsToAdd);
                 }
-                else if (!options.CanUpdateIssue && labelsToAdd.Any())
+                else if (!options.CanUpdateLabels && labelsToAdd.Any())
                 {
                     _logger.LogInformation($"! skipped adding labels for {issueOrPr} {number}. would have been added: {string.Join(",", labelsToAdd)}");
                 }

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/Models/Labeler.cs
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                         NoAreaDeterminedSkipComment = _configuration.GetValue<bool>($"{owner}:{repo}:no_area_determined:skip_comment", false),
 
                         DelayLabelingSeconds = _configuration.GetValue<int>($"{owner}:{repo}:delay_labeling_seconds", 0),
-                        SkipLabelingForAuthor = (string author) => _configuration.GetValue<bool>($"{owner}:{repo}:skip_labeling_for_author:{author}", false),
+                        SkipLabelingForAuthors = _configuration.GetValue<string>($"{owner}:{repo}:skip_labeling_for_authors", "").Split(new[] { ',', ';', ' '}),
                         SkipPrediction = _configuration.GetValue<bool>($"{owner}:{repo}:skip_prediction", false),
                         SkipUntriagedLabel = _configuration.GetValue<bool>($"{owner}:{repo}:skip_untriaged_label", false),
                     });
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             public bool NoAreaDeterminedSkipComment { get; init; }
 
             public int DelayLabelingSeconds { get; init; }
-            public Func<string, bool> SkipLabelingForAuthor { get; init; }
+            public string[] SkipLabelingForAuthors { get; init; }
             public bool SkipPrediction { get; init; }
             public bool SkipUntriagedLabel { get; init; }
         }
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             var labels = new HashSet<string>();
             GithubObjectType issueOrPr = iop.PullRequest != null ? GithubObjectType.PullRequest : GithubObjectType.Issue;
 
-            if (options.SkipLabelingForAuthor(iop.User.Login))
+            if (options.SkipLabelingForAuthors.Contains(iop.User.Login, StringComparer.OrdinalIgnoreCase))
             {
                 _logger.LogInformation($"! dispatcher app - skipped labeling for author '{iop.User.Location}' on {owner}/{repo} {issueOrPr} {number}.");
                 return;

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/appsettings.Development.json
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/appsettings.Development.json
@@ -10,7 +10,10 @@
       "new_api_pr_label": "new-api-needs-documentation",
       "apply_linked_issue_area_label_to_pr": true,
       "skip_prediction": false,
-      "skip_untriaged_label": true
+      "skip_untriaged_label": true,
+      "no_area_determined": {
+        "skip_comment": true
+      }
     },
     "roslyn": {
       "threshold": "0.4",

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/appsettings.Development.json
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/appsettings.Development.json
@@ -5,13 +5,21 @@
       "threshold": "0.4",
       "prediction_url": "",
       "can_update_labels": false,
-      "can_comment_on": false
+      "can_comment_on": false,
+      "area_owners_doc": "https://github.com/dotnet/runtime/blob/main/docs/area-owners.md",
+      "new_api_pr_label": "new-api-needs-documentation",
+      "apply_linked_issue_area_label_to_pr": true,
+      "skip_prediction": false,
+      "skip_untriaged_label": true
     },
     "roslyn": {
       "threshold": "0.4",
       "prediction_url": "",
       "can_update_labels": false,
-      "can_comment_on": false
+      "can_comment_on": false,
+      "skip_labeling_for_author": {
+        "dotnet-bot": true
+      }
     },
     "sdk": {
       "threshold": "0.99",

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/appsettings.Development.json
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/appsettings.Development.json
@@ -1,33 +1,79 @@
 {
-  "dotnet":
-  {
-    "runtime": {
-      "threshold": "0.4",
-      "prediction_url": "",
-      "can_update_labels": false,
+  "dotnet": {
+    "aspnetcore": {
+      "can_comment_on": true,
+      "can_update_labels": true,
+      "no_area_determined": {
+        "label": "needs-area-label"
+      },
+      "threshold": 0.4,
+      "untriaged_label_disabled": true
+    },
+    "deployment-tools": {
       "can_comment_on": false,
-      "area_owners_doc": "https://github.com/dotnet/runtime/blob/main/docs/area-owners.md",
-      "new_api_pr_label": "new-api-needs-documentation",
-      "apply_linked_issue_area_label_to_pr": true,
-      "skip_prediction": false,
-      "skip_untriaged_label": true,
+      "can_update_labels": false,
       "no_area_determined": {
         "skip_comment": true
-      }
+      },
+      "skip_prediction": true,
+      "threshold": 0.4
+    },
+    "docker-tools": {
+      "can_comment_on": false,
+      "can_update_labels": false,
+      "threshold": 0.4
+    },
+    "dotnet-api-docs": {
+      "apply_linked_issue_area_label_to_pr": true,
+      "can_comment_on": false,
+      "can_update_labels": false,
+      "delay_labeling_seconds": 10,
+      "threshold": 0.6,
+      "untriaged_label_disabled": true
+    },
+    "dotnet-buildtools-prereqs-docker": {
+      "can_comment_on": false,
+      "can_update_labels": false,
+      "threshold": 0.4
+    },
+    "dotnet-docker": {
+      "can_comment_on": false,
+      "can_update_labels": false,
+      "threshold": 0.4
     },
     "roslyn": {
-      "threshold": "0.4",
-      "prediction_url": "",
-      "can_update_labels": false,
-      "can_comment_on": false,
-      "skip_labeling_for_authors": "dotnet-bot"
+      "can_comment_on": true,
+      "can_update_labels": true,
+      "skip_labeling_for_authors": "dotnet-bot",
+      "threshold": 0.4
+    },
+    "runtime": {
+      "apply_linked_issue_area_label_to_pr": true,
+      "can_comment_on": true,
+      "can_update_labels": true,
+      "new_api_pr_label": "new-api-needs-documentation",
+      "no_area_determined": {
+        "label": "needs-area-label",
+        "skip_comment": true
+      },
+      "skip_untriaged_label": true,
+      "threshold": 0.4
     },
     "sdk": {
-      "threshold": "0.99",
-      "prediction_url": "",
-      "can_update_labels": false,
+      "apply_linked_issue_area_label_to_pr": true,
       "can_comment_on": false,
-      "delay_labeling_seconds": 10
+      "can_update_labels": false,
+      "threshold": 0.4
+    },
+    "source-build": {
+      "can_comment_on": false,
+      "can_update_labels": false,
+      "threshold": 0.6
+    },
+    "dotnet-framework-docker": {
+      "can_comment_on": false,
+      "can_update_labels": false,
+      "threshold": 0.4
     }
   },
   "QueueName": "",

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/appsettings.Development.json
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/appsettings.Development.json
@@ -20,9 +20,7 @@
       "prediction_url": "",
       "can_update_labels": false,
       "can_comment_on": false,
-      "skip_labeling_for_author": {
-        "dotnet-bot": true
-      }
+      "skip_labeling_for_authors": "dotnet-bot"
     },
     "sdk": {
       "threshold": "0.99",

--- a/src/Microsoft.DotNet.GitHub.IssueLabeler/appsettings.Development.json
+++ b/src/Microsoft.DotNet.GitHub.IssueLabeler/appsettings.Development.json
@@ -25,7 +25,8 @@
       "threshold": "0.99",
       "prediction_url": "",
       "can_update_labels": false,
-      "can_comment_on": false
+      "can_comment_on": false,
+      "delay_labeling_seconds": 10
     }
   },
   "QueueName": "",


### PR DESCRIPTION
This moves away from hard-coded conditions for repos and adopts configuration much more heavily. I've also updated the logic for getting settings from config, moving from `GetSection(key).Get<T>()` to `GetValue<T>(key, default)`.

For every condition that has been moved to config in this PR, I've already updated the service configuration to capture what was encoded here.

**These changes have not yet been deployed.** I will await code reviews.