### PR TITLE
Fix an issue with OctokitGraphQL queries

### DIFF
--- a/src/GitHubHelpers/GitHubHelpers.csproj
+++ b/src/GitHubHelpers/GitHubHelpers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\eng\Versions.props" />
   <PropertyGroup>
@@ -17,6 +17,5 @@
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="$(MicrosoftExtensionsLoggingAzureAppServices)" />
     <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
     <PackageReference Include="Octokit" Version="$(OctokitVersion)" />
-    <PackageReference Include="Octokit.GraphQL" Version="$(OctokitGraphQLVersion)" />
   </ItemGroup>
 </Project>

--- a/src/ModelCreator/Downloader/CommonHelper.cs
+++ b/src/ModelCreator/Downloader/CommonHelper.cs
@@ -58,7 +58,7 @@ public static class CommonHelper
     public static string GetCompressedLine(
         IReadOnlyList<string> filePaths,
         string area,
-        string authorLogin,
+        string? authorLogin,
         string prBody,
         string prTitle,
         DateTimeOffset prCreatedAt,

--- a/src/ModelCreator/Downloader/OctokitGraphQLDownloadHelper.cs
+++ b/src/ModelCreator/Downloader/OctokitGraphQLDownloadHelper.cs
@@ -216,7 +216,7 @@ public static class OctokitGraphQLDownloadHelper
                 Items = connection.Nodes.Select(issue => new
                 {
                     Number = issue.Number,
-                    AuthorLogin = issue.Author.Login,
+                    AuthorLogin = issue.Author == null ? null : issue.Author.Login,
                     Body = issue.Body,
                     Title = issue.Title,
                     CreatedAt = issue.CreatedAt
@@ -396,7 +396,7 @@ public static class OctokitGraphQLDownloadHelper
                     {
                         Number = issue.Number,
                         Labels = issue.Labels(null, null, null, null, null).AllPages().Select(x => x.Name).ToList(),
-                        AuthorLogin = issue.Author.Login,
+                        AuthorLogin = issue.Author == null ? null : issue.Author.Login,
                         Body = issue.Body,
                         Title = issue.Title,
                         CreatedAt = issue.CreatedAt

--- a/src/PredictionEngine/PredictionEngine.csproj
+++ b/src/PredictionEngine/PredictionEngine.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\eng\Versions.props" />
   <PropertyGroup>
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="$(MicrosoftExtensionsLoggingAzureAppServices)" />
     <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
     <PackageReference Include="Octokit" Version="$(OctokitVersion)" />
-    <PackageReference Include="Octokit.GraphQL" Version="$(OctokitGraphQLVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Author may be null and the select expression will fail - resulting in the entire query being skipped. 

This code is currently down a dead codepath since `fastDownload` is hard-coded to `true`.
https://github.com/dotnet/issue-labeler/blob/0571c524404b80334144e365a4449bb111565ceb/src/ModelCreator/Downloader/DownloadHelper.cs#L13-L30

I found this when testing out Octokit.GraphQL and figured I'd fix it even though the code path is dead.  If I have some more time I'll look more closely at this tool and see if there are more improvements we can make.