### PR TITLE
Stage the v1.0.0 release

### DIFF
--- a/.github/workflows/build-predictor.yml
+++ b/.github/workflows/build-predictor.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotnet/issue-labeler
+          ref: 596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/download-issues.yml
+++ b/.github/workflows/download-issues.yml
@@ -97,6 +97,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotnet/issue-labeler
+          ref: 596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/download-pulls.yml
+++ b/.github/workflows/download-pulls.yml
@@ -97,6 +97,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotnet/issue-labeler
+          ref: 596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/labeler-build-predictor.yml
+++ b/.github/workflows/labeler-build-predictor.yml
@@ -12,6 +12,6 @@ jobs:
   build-predictor:
     permissions:
       actions: write
-    uses: dotnet/issue-labeler/.github/workflows/build-predictor.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/build-predictor.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       rebuild: ${{ inputs.rebuild }}

--- a/.github/workflows/labeler-cache-retention.yml
+++ b/.github/workflows/labeler-cache-retention.yml
@@ -10,4 +10,4 @@ jobs:
   cache-retention:
     # Do not run the workflow on forks outside the 'dotnet' org
     if: ${{ github.repository_owner == 'dotnet' }}
-    uses: dotnet/issue-labeler/.github/workflows/cache-retention.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/cache-retention.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ github.repository_owner == 'dotnet' && (inputs.issue_numbers || github.event.issue.number) }}
     permissions:
       issues: write
-    uses: dotnet/issue-labeler/.github/workflows/predict-issues.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/predict-issues.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       model_cache_key: ${{ inputs.model_cache_key }}
       issue_numbers: ${{ inputs.issue_numbers || github.event.issue.number }}

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -32,7 +32,7 @@ jobs:
     if: ${{ github.repository_owner == 'dotnet' && (inputs.pull_numbers || github.event.number) }}
     permissions:
       pull-requests: write
-    uses: dotnet/issue-labeler/.github/workflows/predict-pulls.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/predict-pulls.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       model_cache_key: ${{ inputs.model_cache_key }}
       pull_numbers: ${{ inputs.pull_numbers || github.event.number }}

--- a/.github/workflows/labeler-promote.yml
+++ b/.github/workflows/labeler-promote.yml
@@ -29,14 +29,14 @@ permissions:
 jobs:
   labeler-promote-issues:
     if: ${{ inputs.promote_issues }}
-    uses: dotnet/issue-labeler/.github/workflows/promote-issues.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/promote-issues.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       model_cache_key: ${{ inputs.model_cache_key }}
       backup_cache_key: ${{ inputs.backup_cache_key }}
 
   labeler-promote-pulls:
     if: ${{ inputs.promote_pulls }}
-    uses: dotnet/issue-labeler/.github/workflows/promote-pulls.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/promote-pulls.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       model_cache_key: ${{ inputs.model_cache_key }}
       backup_cache_key: ${{ inputs.backup_cache_key }}

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -52,7 +52,7 @@ jobs:
       issues: read
       pull-requests: read
       actions: write
-    uses: dotnet/issue-labeler/.github/workflows/train.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/train.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       download_issues: ${{ inputs.download_issues }}
       train_issues: ${{ inputs.train_issues }}

--- a/.github/workflows/test-issues.yml
+++ b/.github/workflows/test-issues.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotnet/issue-labeler
+          ref: 596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/test-pulls.yml
+++ b/.github/workflows/test-pulls.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotnet/issue-labeler
+          ref: 596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/train-issues.yml
+++ b/.github/workflows/train-issues.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotnet/issue-labeler
+          ref: 596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/train-pulls.yml
+++ b/.github/workflows/train-pulls.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotnet/issue-labeler
+          ref: 596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -48,7 +48,7 @@ on:
 
 jobs:
   build-predictor:
-    uses: dotnet/issue-labeler/.github/workflows/build-predictor.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/build-predictor.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
 
   labeler-download-issues:
     needs: build-predictor
@@ -56,7 +56,7 @@ jobs:
     permissions:
       issues: read
       actions: write
-    uses: dotnet/issue-labeler/.github/workflows/download-issues.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/download-issues.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       github_token: ${{ inputs.github_token || github.token }}
       repository: ${{ inputs.repository || github.repository }}
@@ -69,7 +69,7 @@ jobs:
     if: ${{ inputs.train_issues && always() && (needs.labeler-download-issues.result == 'success' || needs.labeler-download-issues.result == 'skipped') }}
     permissions:
       actions: write
-    uses: dotnet/issue-labeler/.github/workflows/train-issues.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/train-issues.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       data_cache_key: ${{ inputs.cache_key_suffix }}
       model_cache_key: ${{ inputs.cache_key_suffix }}
@@ -77,7 +77,7 @@ jobs:
   labeler-test-issues:
     needs: [labeler-download-issues, labeler-train-issues]
     if: ${{ inputs.test_issues && always() && (needs.labeler-download-issues.result == 'success' || needs.labeler-download-issues.result == 'skipped') && (needs.labeler-train-issues.result == 'success' || needs.labeler-train-issues.result == 'skipped') }}
-    uses: dotnet/issue-labeler/.github/workflows/test-issues.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/test-issues.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       github_token: ${{ inputs.github_token || github.token }}
       repository: ${{ inputs.repository || github.repository }}
@@ -91,7 +91,7 @@ jobs:
     permissions:
       pull-requests: read
       actions: write
-    uses: dotnet/issue-labeler/.github/workflows/download-pulls.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/download-pulls.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       github_token: ${{ inputs.github_token || github.token }}
       repository: ${{ inputs.repository || github.repository }}
@@ -104,7 +104,7 @@ jobs:
     if: ${{ inputs.train_pulls && always() && (needs.labeler-download-pulls.result == 'success' || needs.labeler-download-pulls.result == 'skipped') }}
     permissions:
       actions: write
-    uses: dotnet/issue-labeler/.github/workflows/train-pulls.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/train-pulls.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       data_cache_key: ${{ inputs.cache_key_suffix }}
       model_cache_key: ${{ inputs.cache_key_suffix }}
@@ -112,7 +112,7 @@ jobs:
   labeler-test-pulls:
     needs: [labeler-download-pulls, labeler-train-pulls]
     if: ${{ inputs.test_pulls && always() && (needs.labeler-download-pulls.result == 'success' || needs.labeler-download-pulls.result == 'skipped') && (needs.labeler-train-pulls.result == 'success' || needs.labeler-train-pulls.result == 'skipped') }}
-    uses: dotnet/issue-labeler/.github/workflows/test-pulls.yml@596dc78 # v1.0.0
+    uses: dotnet/issue-labeler/.github/workflows/test-pulls.yml@596dc78dcf246d381a6df15fd63b9468798a03cd # Staging v1.0.0
     with:
       github_token: ${{ inputs.github_token || github.token }}
       repository: ${{ inputs.repository || github.repository }}


### PR DESCRIPTION
This build on #85, addressing 3 follow-up items:
1. Pinning a workflow reference to a SHA requires the full SHA
2. We need to pin to the SHA for the actions/checkout references that checkout and build the code from this repo
3. Update comments on these SHA pin comments because the SHA referenced within this repo will be the parent of the SHA that consumers need to pin to

Once this is merged, the v1.0.0 Release will be updated to point to this PR's commit SHA.