### PR TITLE
Add retry/error handling to the Predictor

### DIFF
--- a/src/Downloader/Args.cs
+++ b/src/Downloader/Args.cs
@@ -53,7 +53,7 @@ public struct Args
 
     public static Args? Parse(string[] args)
     {
-        Args config = new()
+        Args argsData = new()
         {
             Retries = [30, 30, 300, 300, 3000, 3000]
         };
@@ -70,7 +70,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.GithubToken = token;
+                    argsData.GithubToken = token;
                     break;
 
                 case "--repo":
@@ -78,8 +78,8 @@ public struct Args
                     {
                         return null;
                     }
-                    config.Org = org;
-                    config.Repos = repos;
+                    argsData.Org = org;
+                    argsData.Repos = repos;
                     break;
 
                 case "--issue-data":
@@ -87,7 +87,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.IssueDataPath = issueDataPath;
+                    argsData.IssueDataPath = issueDataPath;
                     break;
 
                 case "--issue-limit":
@@ -95,7 +95,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.IssueLimit = issueLimit;
+                    argsData.IssueLimit = issueLimit;
                     break;
 
                 case "--pull-data":
@@ -103,7 +103,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.PullDataPath = pullDataPath;
+                    argsData.PullDataPath = pullDataPath;
                     break;
 
                 case "--pull-limit":
@@ -111,7 +111,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.PullLimit = pullLimit;
+                    argsData.PullLimit = pullLimit;
                     break;
 
                 case "--page-size":
@@ -119,7 +119,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.PageSize = pageSize;
+                    argsData.PageSize = pageSize;
                     break;
 
                 case "--page-limit":
@@ -127,7 +127,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.PageLimit = pageLimit;
+                    argsData.PageLimit = pageLimit;
                     break;
 
                 case "--retries":
@@ -135,7 +135,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.Retries = retries;
+                    argsData.Retries = retries;
                     break;
 
                 case "--label-prefix":
@@ -143,11 +143,11 @@ public struct Args
                     {
                         return null;
                     }
-                    config.LabelPredicate = new(labelPredicate);
+                    argsData.LabelPredicate = new(labelPredicate);
                     break;
 
                 case "--verbose":
-                    config.Verbose = true;
+                    argsData.Verbose = true;
                     break;
                 default:
                     ShowUsage($"Unrecognized argument: {argument}");
@@ -155,14 +155,14 @@ public struct Args
             }
         }
 
-        if (config.Org is null || config.Repos is null || config.LabelPredicate is null ||
-            (config.IssueDataPath is null && config.PullDataPath is null))
+        if (argsData.Org is null || argsData.Repos is null || argsData.LabelPredicate is null ||
+            (argsData.IssueDataPath is null && argsData.PullDataPath is null))
         {
             ShowUsage();
             return null;
         }
 
-        if (config.GithubToken is null)
+        if (argsData.GithubToken is null)
         {
             string? token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
 
@@ -172,9 +172,9 @@ public struct Args
                 return null;
             }
 
-            config.GithubToken = token;
+            argsData.GithubToken = token;
         }
 
-        return config;
+        return argsData;
     }
 }

--- a/src/Tester/Args.cs
+++ b/src/Tester/Args.cs
@@ -58,7 +58,7 @@ public struct Args
 
     public static Args? Parse(string[] args)
     {
-        Args config = new()
+        Args argsData = new()
         {
             Threshold = 0.4f
         };
@@ -75,7 +75,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.GithubToken = token;
+                    argsData.GithubToken = token;
                     break;
 
                 case "--repo":
@@ -83,8 +83,8 @@ public struct Args
                     {
                         return null;
                     }
-                    config.Org = org;
-                    config.Repos = repos;
+                    argsData.Org = org;
+                    argsData.Repos = repos;
                     break;
 
                 case "--issue-data":
@@ -92,7 +92,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.IssueDataPath = issueDataPath;
+                    argsData.IssueDataPath = issueDataPath;
                     break;
 
                 case "--issue-model":
@@ -100,7 +100,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.IssueModelPath = issueModelPath;
+                    argsData.IssueModelPath = issueModelPath;
                     break;
 
                 case "--issue-limit":
@@ -108,7 +108,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.IssueLimit = issueLimit;
+                    argsData.IssueLimit = issueLimit;
                     break;
 
                 case "--pull-data":
@@ -116,7 +116,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.PullDataPath = pullDataPath;
+                    argsData.PullDataPath = pullDataPath;
                     break;
 
                 case "--pull-model":
@@ -124,7 +124,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.PullModelPath = pullModelPath;
+                    argsData.PullModelPath = pullModelPath;
                     break;
 
                 case "--pull-limit":
@@ -132,7 +132,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.PullLimit = pullLimit;
+                    argsData.PullLimit = pullLimit;
                     break;
 
                 case "--label-prefix":
@@ -140,7 +140,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.LabelPredicate = new(labelPredicate);
+                    argsData.LabelPredicate = new(labelPredicate);
                     break;
 
                 case "--threshold":
@@ -148,7 +148,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.Threshold = threshold.Value;
+                    argsData.Threshold = threshold.Value;
                     break;
 
                 default:
@@ -157,18 +157,18 @@ public struct Args
             }
         }
 
-        if (config.LabelPredicate is null ||
+        if (argsData.LabelPredicate is null ||
             (
-                config.IssueDataPath is null && config.PullDataPath is null &&
-                (config.Org is null || config.Repos.Count == 0 || config.GithubToken is null)
+                argsData.IssueDataPath is null && argsData.PullDataPath is null &&
+                (argsData.Org is null || argsData.Repos.Count == 0 || argsData.GithubToken is null)
             ) ||
-            (config.IssueModelPath is null && config.PullModelPath is null)
+            (argsData.IssueModelPath is null && argsData.PullModelPath is null)
         )
         {
             ShowUsage();
             return null;
         }
 
-        return config;
+        return argsData;
     }
 }

--- a/src/Trainer/Args.cs
+++ b/src/Trainer/Args.cs
@@ -37,7 +37,7 @@ public struct Args
 
     public static Args? Parse(string[] args)
     {
-        Args config = new();
+        Args argsData = new();
 
         Queue<string> arguments = new(args);
         while (arguments.Count > 0)
@@ -51,7 +51,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.IssueDataPath = issueDataPath;
+                    argsData.IssueDataPath = issueDataPath;
                     break;
 
                 case "--issue-model":
@@ -59,7 +59,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.IssueModelPath = issueModelPath;
+                    argsData.IssueModelPath = issueModelPath;
                     break;
 
                 case "--pull-data":
@@ -67,7 +67,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.PullDataPath = pullDataPath;
+                    argsData.PullDataPath = pullDataPath;
                     break;
 
                 case "--pull-model":
@@ -75,7 +75,7 @@ public struct Args
                     {
                         return null;
                     }
-                    config.PullModelPath = pullModelPath;
+                    argsData.PullModelPath = pullModelPath;
                     break;
 
                 default:
@@ -84,14 +84,14 @@ public struct Args
             }
         }
 
-        if ((config.IssueDataPath is null != config.IssueModelPath is null) ||
-            (config.PullDataPath is null != config.PullModelPath is null) ||
-            (config.IssueModelPath is null && config.PullModelPath is null))
+        if ((argsData.IssueDataPath is null != argsData.IssueModelPath is null) ||
+            (argsData.PullDataPath is null != argsData.PullModelPath is null) ||
+            (argsData.IssueModelPath is null && argsData.PullModelPath is null))
         {
             ShowUsage();
             return null;
         }
 
-        return config;
+        return argsData;
     }
 }


### PR DESCRIPTION
Fixes #92

The code path for Downloader had sufficient error handling and retry logic, as did the code path for applying/removing labels. But the API calls for fetchinng individual issues/pulls did not. This affected the Predictor when running bulk jobs, resuling in a NullReferenceException when trying to access the `.Data.Repository` property on the GraphQL response.

See #93 for opportunities for further improvement after these changes here.