### PR TITLE
Add discussion labeling to issues labeler workflow

### DIFF
--- a/.github/workflows/labeler-cache-retention.yml
+++ b/.github/workflows/labeler-cache-retention.yml
@@ -20,8 +20,8 @@ env:
 
 jobs:
   restore-cache:
-    # Do not automatically run the workflow on forks outside the 'dotnet' org
-    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet' }}
+    # Do not automatically run the workflow on forked repositories
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.repository.fork }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/labeler-predict-discussions.yml
+++ b/.github/workflows/labeler-predict-discussions.yml
@@ -1,16 +1,16 @@
-# Predict labels for Issues using a trained model
-name: "Labeler: Predict (Issues)"
+# Predict labels for Discussions using a trained model
+name: "Labeler: Predict (Discussions)"
 
 on:
-  # Only automatically predict area labels when issues are first opened
-  issues:
-    types: [opened]
+  # Only automatically predict area labels when discussions are first created
+  discussion:
+    types: [created]
 
   # Allow dispatching the workflow via the Actions UI, specifying ranges of numbers
   workflow_dispatch:
     inputs:
-      issues:
-        description: "Issue Numbers (comma-separated list of ranges)."
+      discussions:
+        description: "Discussion Numbers (comma-separated list of ranges)."
         required: true
       cache_key:
         description: "The cache key suffix to use for restoring the model. Defaults to 'ACTIVE'."
@@ -23,32 +23,33 @@ env:
   DEFAULT_LABEL: "needs-area-label"
 
 jobs:
-  predict-issue-label:
+  predict-discussion-label:
     # Do not automatically run on forks outside the 'dotnet' org
     if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet' }}
     runs-on: ubuntu-latest
     permissions:
+      discussions: write
       issues: write
     steps:
-      - name: "Restore issues model from cache"
+      - name: "Restore discussions model from cache"
         id: restore-model
         uses: dotnet/issue-labeler/restore@main
         with:
-          type: issues
+          type: discussions
           fail-on-cache-miss: ${{ github.event_name == 'workflow_dispatch' }}
           quiet: true
           cache_key: ${{ github.event.inputs.cache_key || 'ACTIVE' }}
 
-      - name: "Predict issue labels"
-        id: prediction
+      - name: "Predict discussion labels"
         if: ${{ steps.restore-model.outputs.cache-hit == 'true' }}
         uses: dotnet/issue-labeler/predict@main
         with:
-          issues: ${{ github.event.inputs.issues || github.event.issue.number }}
+          discussions: ${{ github.event.inputs.discussions || github.event.discussion.number }}
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}
           test: ${{ vars.LABELER_TEST_MODE || 'true' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          INPUT_ISSUES_MODEL: labeler-cache/discussions-model.zip
         continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/labeler-predict-discussions.yml
+++ b/.github/workflows/labeler-predict-discussions.yml
@@ -22,6 +22,7 @@ on:
         default: "ACTIVE"
 
 env:
+  ALLOW_FAILURE: ${{ github.event_name != 'workflow_dispatch' }}
   LABEL_PREFIX: "area-"
   THRESHOLD: 0.40
   DEFAULT_LABEL: "needs-area-label"
@@ -40,7 +41,7 @@ jobs:
         uses: dotnet/issue-labeler/restore@main
         with:
           type: discussions
-          fail-on-cache-miss: ${{ github.event_name == 'workflow_dispatch' }}
+          fail-on-cache-miss: ${{ !fromJSON(env.ALLOW_FAILURE) }}
           quiet: true
           cache_key: ${{ github.event.inputs.cache_key || 'ACTIVE' }}
 
@@ -56,4 +57,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           INPUT_ISSUES_MODEL: labeler-cache/discussions-model.zip
-        continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}
+        continue-on-error: ${{ fromJSON(env.ALLOW_FAILURE) }}

--- a/.github/workflows/labeler-predict-discussions.yml
+++ b/.github/workflows/labeler-predict-discussions.yml
@@ -12,6 +12,10 @@ on:
       discussions:
         description: "Discussion Numbers (comma-separated list of ranges)."
         required: true
+      dry_run:
+        description: "Run in dry-run mode for manual dispatches. Defaults to 'true'."
+        required: false
+        default: "true"
       cache_key:
         description: "The cache key suffix to use for restoring the model. Defaults to 'ACTIVE'."
         required: true
@@ -24,8 +28,8 @@ env:
 
 jobs:
   predict-discussion-label:
-    # Do not automatically run on forks outside the 'dotnet' org
-    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet' }}
+    # Do not automatically run on forked repositories
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.repository.fork }}
     runs-on: ubuntu-latest
     permissions:
       discussions: write
@@ -48,7 +52,7 @@ jobs:
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}
-          test: ${{ vars.LABELER_TEST_MODE || 'true' }}
+          dry_run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           INPUT_ISSUES_MODEL: labeler-cache/discussions-model.zip

--- a/.github/workflows/labeler-predict-discussions.yml
+++ b/.github/workflows/labeler-predict-discussions.yml
@@ -24,7 +24,7 @@ on:
 env:
   ALLOW_FAILURE: ${{ github.event_name != 'workflow_dispatch' }}
   LABEL_PREFIX: "area-"
-  THRESHOLD: 0.40
+  THRESHOLD: ${{ vars.ISSUE_LABELER_PREDICTION_THRESHOLD || '0.15' }}
   DEFAULT_LABEL: "needs-area-label"
 
 jobs:

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -22,6 +22,7 @@ on:
         default: "ACTIVE"
 
 env:
+  ALLOW_FAILURE: ${{ github.event_name != 'workflow_dispatch' }}
   LABEL_PREFIX: "area-"
   THRESHOLD: 0.40
   DEFAULT_LABEL: "needs-area-label"
@@ -39,7 +40,7 @@ jobs:
         uses: dotnet/issue-labeler/restore@main
         with:
           type: issues
-          fail-on-cache-miss: ${{ github.event_name == 'workflow_dispatch' }}
+          fail-on-cache-miss: ${{ !fromJSON(env.ALLOW_FAILURE) }}
           quiet: true
           cache_key: ${{ github.event.inputs.cache_key || 'ACTIVE' }}
 
@@ -55,4 +56,4 @@ jobs:
           dry_run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}
+        continue-on-error: ${{ fromJSON(env.ALLOW_FAILURE) }}

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -50,6 +50,7 @@ jobs:
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}
+          test: ${{ vars.LABELER_TEST_MODE || 'true' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}
@@ -79,7 +80,7 @@ jobs:
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}
-          test: ${{ vars.DISCUSSIONS_TEST || 'false' }}
+          test: ${{ vars.LABELER_TEST_MODE || 'true' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -79,6 +79,7 @@ jobs:
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}
+          test: ${{ vars.DISCUSSIONS_TEST || 'false' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -47,7 +47,6 @@ jobs:
         uses: dotnet/issue-labeler/predict@main
         with:
           issues: ${{ inputs.issues || github.event.issue.number }}
-          pulls: ""
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -12,6 +12,10 @@ on:
       issues:
         description: "Issue Numbers (comma-separated list of ranges)."
         required: true
+      dry_run:
+        description: "Run in dry-run mode for manual dispatches. Defaults to 'true'."
+        required: false
+        default: "true"
       cache_key:
         description: "The cache key suffix to use for restoring the model. Defaults to 'ACTIVE'."
         required: true
@@ -24,8 +28,8 @@ env:
 
 jobs:
   predict-issue-label:
-    # Do not automatically run on forks outside the 'dotnet' org
-    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet' }}
+    # Do not automatically run on forked repositories
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.repository.fork }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -48,7 +52,7 @@ jobs:
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}
-          test: ${{ vars.LABELER_TEST_MODE || 'true' }}
+          dry_run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -39,14 +39,14 @@ jobs:
           type: issues
           fail-on-cache-miss: ${{ github.event_name == 'workflow_dispatch' }}
           quiet: true
-          cache_key: ${{ inputs.cache_key || 'ACTIVE' }}
+          cache_key: ${{ github.event.inputs.cache_key || 'ACTIVE' }}
 
       - name: "Predict issue labels"
         id: prediction
         if: ${{ steps.restore-model.outputs.cache-hit == 'true' }}
         uses: dotnet/issue-labeler/predict@main
         with:
-          issues: ${{ inputs.issues || github.event.issue.number }}
+          issues: ${{ github.event.inputs.issues || github.event.issue.number }}
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -1,10 +1,12 @@
-# Predict labels for Issues using a trained model
+# Predict labels for Issues and Discussions using a trained model
 name: "Labeler: Predict (Issues)"
 
 on:
   # Only automatically predict area labels when issues are first opened
   issues:
-    types: opened
+    types: [opened]
+  discussion:
+    types: [created]
 
   # Allow dispatching the workflow via the Actions UI, specifying ranges of numbers
   workflow_dispatch:
@@ -18,17 +20,14 @@ on:
         default: "ACTIVE"
 
 env:
-  # Do not allow failure for jobs triggered automatically (as this causes red noise on the workflows list)
-  ALLOW_FAILURE: ${{ github.event_name == 'workflow_dispatch' }}
-
   LABEL_PREFIX: "area-"
   THRESHOLD: 0.40
   DEFAULT_LABEL: "needs-area-label"
 
 jobs:
   predict-issue-label:
-    # Do not automatically run the workflow on forks outside the 'dotnet' org
-    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet' }}
+    # Do not automatically run on discussion events or on forks outside the 'dotnet' org
+    if: ${{ github.event_name != 'discussion' && (github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -38,8 +37,9 @@ jobs:
         uses: dotnet/issue-labeler/restore@main
         with:
           type: issues
-          fail-on-cache-miss: ${{ env.ALLOW_FAILURE }}
+          fail-on-cache-miss: ${{ github.event_name == 'workflow_dispatch' }}
           quiet: true
+          cache_key: ${{ inputs.cache_key || 'ACTIVE' }}
 
       - name: "Predict issue labels"
         id: prediction
@@ -47,9 +47,62 @@ jobs:
         uses: dotnet/issue-labeler/predict@main
         with:
           issues: ${{ inputs.issues || github.event.issue.number }}
+          pulls: ""
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        continue-on-error: ${{ !env.ALLOW_FAILURE }}
+        continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}
+
+  label-discussion:
+    # Only run on discussion events, and only on the 'dotnet' org (not forks)
+    if: ${{ github.event_name == 'discussion' && github.repository_owner == 'dotnet' }}
+    runs-on: ubuntu-latest
+    permissions:
+      discussions: write
+      issues: read
+    steps:
+      - name: "Apply default area label to discussion"
+        uses: actions/github-script@v7
+        env:
+          DEFAULT_LABEL: ${{ env.DEFAULT_LABEL }}
+        with:
+          script: |
+            const labelName = process.env.DEFAULT_LABEL;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const discussionNodeId = context.payload.discussion?.node_id;
+            const discussionNumber = context.payload.discussion?.number;
+
+            if (!discussionNodeId || !discussionNumber) {
+              core.setFailed("Missing discussion node ID or number in event payload.");
+              return;
+            }
+
+            // Resolve the label node ID (create the label if it doesn't exist yet)
+            let labelNodeId;
+            try {
+              const existingLabel = await github.rest.issues.getLabel({ owner, repo, name: labelName });
+              labelNodeId = existingLabel.data.node_id;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              const createdLabel = await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: labelName,
+                color: "ededed",
+                description: "Added by labeler workflow when no area could be predicted"
+              });
+              labelNodeId = createdLabel.data.node_id;
+            }
+
+            // Apply the label to the discussion via GraphQL (REST labels API does not support discussions)
+            await github.graphql(
+              `mutation($labelableId: ID!, $labelIds: [ID!]!) {
+                addLabelsToLabelable(input: { labelableId: $labelableId, labelIds: $labelIds }) {
+                  clientMutationId
+                }
+              }`,
+              { labelableId: discussionNodeId, labelIds: [labelNodeId] }
+            );

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -61,8 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       discussions: write
-      issues: read
-    steps:
+      issues: write
       - name: "Apply default area label to discussion"
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -63,46 +63,23 @@ jobs:
       discussions: write
       issues: write
     steps:
-      - name: "Apply default area label to discussion"
-        uses: actions/github-script@v7
-        env:
-          DEFAULT_LABEL: ${{ env.DEFAULT_LABEL }}
+      - name: "Restore issues model from cache"
+        id: restore-model
+        uses: dotnet/issue-labeler/restore@main
         with:
-          script: |
-            const labelName = process.env.DEFAULT_LABEL;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const discussionNodeId = context.payload.discussion?.node_id;
-            const discussionNumber = context.payload.discussion?.number;
+          type: issues
+          fail-on-cache-miss: false
+          quiet: true
+          cache_key: 'ACTIVE'
 
-            if (!discussionNodeId || !discussionNumber) {
-              core.setFailed("Missing discussion node ID or number in event payload.");
-              return;
-            }
-
-            // Resolve the label node ID (create the label if it doesn't exist yet)
-            let labelNodeId;
-            try {
-              const existingLabel = await github.rest.issues.getLabel({ owner, repo, name: labelName });
-              labelNodeId = existingLabel.data.node_id;
-            } catch (error) {
-              if (error.status !== 404) throw error;
-              const createdLabel = await github.rest.issues.createLabel({
-                owner,
-                repo,
-                name: labelName,
-                color: "ededed",
-                description: "Added by labeler workflow when no area could be predicted"
-              });
-              labelNodeId = createdLabel.data.node_id;
-            }
-
-            // Apply the label to the discussion via GraphQL (REST labels API does not support discussions)
-            await github.graphql(
-              `mutation($labelableId: ID!, $labelIds: [ID!]!) {
-                addLabelsToLabelable(input: { labelableId: $labelableId, labelIds: $labelIds }) {
-                  clientMutationId
-                }
-              }`,
-              { labelableId: discussionNodeId, labelIds: [labelNodeId] }
-            );
+      - name: "Predict discussion labels"
+        if: ${{ steps.restore-model.outputs.cache-hit == 'true' }}
+        uses: dotnet/issue-labeler/predict@main
+        with:
+          discussions: ${{ github.event.discussion.number }}
+          label_prefix: ${{ env.LABEL_PREFIX }}
+          threshold: ${{ env.THRESHOLD }}
+          default_label: ${{ env.DEFAULT_LABEL }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        continue-on-error: true

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -83,4 +83,5 @@ jobs:
           test: ${{ vars.LABELER_TEST_MODE || 'true' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          INPUT_ISSUES_MODEL: labeler-cache/discussions-model.zip
         continue-on-error: true

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -1,5 +1,5 @@
 # Predict labels for Issues and Discussions using a trained model
-name: "Labeler: Predict (Issues)"
+name: "Labeler: Predict (Issues & Discussions)"
 
 on:
   # Only automatically predict area labels when issues are first opened
@@ -62,6 +62,7 @@ jobs:
     permissions:
       discussions: write
       issues: write
+    steps:
       - name: "Apply default area label to discussion"
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -62,11 +62,11 @@ jobs:
       discussions: write
       issues: write
     steps:
-      - name: "Restore issues model from cache"
+      - name: "Restore discussions model from cache"
         id: restore-model
         uses: dotnet/issue-labeler/restore@main
         with:
-          type: issues
+          type: discussions
           fail-on-cache-miss: false
           quiet: true
           cache_key: 'ACTIVE'

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -36,8 +36,8 @@ env:
 
 jobs:
   predict-pull-label:
-    # Do not automatically run the workflow on forks outside the 'dotnet' org
-    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet' }}
+    # Do not automatically run the workflow on forked repositories
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.repository.fork }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -5,13 +5,14 @@ on:
   workflow_dispatch:
     inputs:
       type:
-        description: "Issues or Pull Requests"
+        description: "Issues, Discussions, or Pull Requests"
         type: choice
         required: true
         default: "Both"
         options:
           - "Both"
           - "Issues"
+          - "Discussions"
           - "Pull Requests"
 
       steps:
@@ -89,6 +90,68 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+  download-discussions:
+    if: ${{ inputs.type == 'Discussions' && contains(fromJSON('["All", "Download Data"]'), inputs.steps) }}
+    runs-on: ubuntu-latest
+    permissions:
+      discussions: read
+    steps:
+      - name: "Download Discussions"
+        uses: dotnet/issue-labeler/download@main
+        with:
+          type: "discussions"
+          cache_key: ${{ env.CACHE_KEY }}
+          repository: ${{ env.REPOSITORY }}
+          label_prefix: ${{ env.LABEL_PREFIX }}
+          limit: ${{ env.LIMIT }}
+          page_size: ${{ env.PAGE_SIZE }}
+          page_limit: ${{ env.PAGE_LIMIT }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  check-discussions-data:
+    if: ${{ always() && inputs.type == 'Discussions' && contains(fromJSON('["All", "Train Model", "Test Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.download-discussions.result) }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    needs: download-discussions
+    outputs:
+      has_training_data: ${{ steps.check.outputs.has_training_data }}
+    steps:
+      - name: "Restore Discussion Data from Cache"
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: labeler-cache/discussions-data.tsv
+          key: issue-labeler/data/discussions/${{ env.CACHE_KEY }}
+          fail-on-cache-miss: true
+
+      - name: "Check Discussion Training Data"
+        id: check
+        shell: bash
+        run: |
+          line_count=$(wc -l < labeler-cache/discussions-data.tsv)
+          if [[ "$line_count" -ge 10 ]]; then
+            echo "has_training_data=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_training_data=false" >> "$GITHUB_OUTPUT"
+            echo "> [!NOTE]" >> "$GITHUB_STEP_SUMMARY"
+            echo "> Discussion training skipped because only $line_count line(s) were found in the downloaded TSV, and the trainer requires at least 10." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  train-discussions:
+    if: ${{ always() && inputs.type == 'Discussions' && contains(fromJSON('["All", "Train Model"]'), inputs.steps) && needs.check-discussions-data.outputs.has_training_data == 'true' && contains(fromJSON('["success", "skipped"]'), needs.download-discussions.result) }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    needs:
+      - download-discussions
+      - check-discussions-data
+    steps:
+      - name: "Train Model for Discussions"
+        uses: dotnet/issue-labeler/train@main
+        with:
+          type: "discussions"
+          data_cache_key: ${{ env.CACHE_KEY }}
+          model_cache_key: ${{ env.CACHE_KEY }}
+
   train-issues:
     if: ${{ always() && contains(fromJSON('["Both", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Train Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.download-issues.result) }}
     runs-on: ubuntu-latest
@@ -126,6 +189,29 @@ jobs:
         uses: dotnet/issue-labeler/test@main
         with:
           type: "issues"
+          cache_key: ${{ env.CACHE_KEY }}
+          repository: ${{ env.REPOSITORY }}
+          label_prefix: ${{ env.LABEL_PREFIX }}
+          threshold: ${{ env.THRESHOLD }}
+          limit: ${{ env.LIMIT }}
+          page_size: ${{ env.PAGE_SIZE }}
+          page_limit: ${{ env.PAGE_LIMIT }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  test-discussions:
+    if: ${{ always() && inputs.type == 'Discussions' && contains(fromJSON('["All", "Test Model"]'), inputs.steps) && needs.check-discussions-data.outputs.has_training_data == 'true' && contains(fromJSON('["success", "skipped"]'), needs.train-discussions.result) }}
+    runs-on: ubuntu-latest
+    permissions:
+      discussions: read
+    needs:
+      - check-discussions-data
+      - train-discussions
+    steps:
+      - name: "Test Model for Discussions"
+        uses: dotnet/issue-labeler/test@main
+        with:
+          type: "discussions"
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -46,8 +46,9 @@ env:
   CACHE_KEY: ${{ inputs.cache_key_suffix }}
   REPOSITORY: ${{ inputs.repository || github.repository }}
   LABEL_PREFIX: "area-"
-  THRESHOLD: "0.40"
-  DISCUSSION_THRESHOLD: ${{ vars.ISSUE_LABELER_PREDICTION_THRESHOLD || '0.15' }}
+  THRESHOLD_ISSUES: ${{ vars.ISSUE_LABELER_PREDICTION_THRESHOLD_ISSUES || vars.ISSUE_LABELER_PREDICTION_THRESHOLD || '0.40' }}
+  THRESHOLD_PULLS: ${{ vars.ISSUE_LABELER_PREDICTION_THRESHOLD_PULLS || vars.ISSUE_LABELER_PREDICTION_THRESHOLD || '0.40' }}
+  THRESHOLD_DISCUSSIONS: ${{ vars.ISSUE_LABELER_PREDICTION_THRESHOLD_DISCUSSIONS || vars.ISSUE_LABELER_PREDICTION_THRESHOLD || '0.15' }}
   LIMIT: ${{ inputs.limit }}
   PAGE_SIZE: ${{ inputs.page_size }}
   PAGE_LIMIT: ${{ inputs.page_limit }}
@@ -255,7 +256,7 @@ jobs:
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
-          threshold: ${{ env.THRESHOLD }}
+          threshold: ${{ env.THRESHOLD_ISSUES }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}
           page_limit: ${{ env.PAGE_LIMIT }}
@@ -278,7 +279,7 @@ jobs:
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
-          threshold: ${{ env.DISCUSSION_THRESHOLD }}
+          threshold: ${{ env.THRESHOLD_DISCUSSIONS }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}
           page_limit: ${{ env.PAGE_LIMIT }}
@@ -301,7 +302,7 @@ jobs:
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
-          threshold: ${{ env.THRESHOLD }}
+          threshold: ${{ env.THRESHOLD_PULLS }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}
           page_limit: ${{ env.PAGE_LIMIT }}

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -1,4 +1,4 @@
-# Train the Issues and Pull Requests models for label prediction
+# Train the Issues, Discussions, and Pull Requests models for label prediction
 name: "Labeler: Training"
 
 on:
@@ -8,9 +8,9 @@ on:
         description: "Issues, Discussions, or Pull Requests"
         type: choice
         required: true
-        default: "Both"
+        default: "All"
         options:
-          - "Both"
+          - "All"
           - "Issues"
           - "Discussions"
           - "Pull Requests"
@@ -53,7 +53,7 @@ env:
 
 jobs:
   download-issues:
-    if: ${{ contains(fromJSON('["Both", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Download Data"]'), inputs.steps) }}
+    if: ${{ contains(fromJSON('["All", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Download Data"]'), inputs.steps) }}
     runs-on: ubuntu-latest
     permissions:
       issues: read
@@ -72,7 +72,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   download-pulls:
-    if: ${{ contains(fromJSON('["Both", "Pull Requests"]'), inputs.type) && contains(fromJSON('["All", "Download Data"]'), inputs.steps) }}
+    if: ${{ contains(fromJSON('["All", "Pull Requests"]'), inputs.type) && contains(fromJSON('["All", "Download Data"]'), inputs.steps) }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -91,7 +91,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   download-discussions:
-    if: ${{ inputs.type == 'Discussions' && contains(fromJSON('["All", "Download Data"]'), inputs.steps) }}
+    if: ${{ contains(fromJSON('["All", "Discussions"]'), inputs.type) && contains(fromJSON('["All", "Download Data"]'), inputs.steps) }}
     runs-on: ubuntu-latest
     permissions:
       discussions: read
@@ -109,8 +109,64 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+  check-issues-data:
+    if: ${{ always() && contains(fromJSON('["All", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Train Model", "Test Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.download-issues.result) }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    needs: download-issues
+    outputs:
+      has_training_data: ${{ steps.check.outputs.has_training_data }}
+    steps:
+      - name: "Restore Issue Data from Cache"
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: labeler-cache/issues-data.tsv
+          key: issue-labeler/data/issues/${{ env.CACHE_KEY }}
+          fail-on-cache-miss: true
+
+      - name: "Check Issue Training Data"
+        id: check
+        shell: bash
+        run: |
+          line_count=$(wc -l < labeler-cache/issues-data.tsv)
+          if [[ "$line_count" -ge 10 ]]; then
+            echo "has_training_data=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_training_data=false" >> "$GITHUB_OUTPUT"
+            echo "> [!NOTE]" >> "$GITHUB_STEP_SUMMARY"
+            echo "> Issue training skipped because only $line_count line(s) were found in the downloaded TSV, and the trainer requires at least 10." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  check-pulls-data:
+    if: ${{ always() && contains(fromJSON('["All", "Pull Requests"]'), inputs.type) && contains(fromJSON('["All", "Train Model", "Test Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.download-pulls.result) }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    needs: download-pulls
+    outputs:
+      has_training_data: ${{ steps.check.outputs.has_training_data }}
+    steps:
+      - name: "Restore Pull Request Data from Cache"
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: labeler-cache/pulls-data.tsv
+          key: issue-labeler/data/pulls/${{ env.CACHE_KEY }}
+          fail-on-cache-miss: true
+
+      - name: "Check Pull Request Training Data"
+        id: check
+        shell: bash
+        run: |
+          line_count=$(wc -l < labeler-cache/pulls-data.tsv)
+          if [[ "$line_count" -ge 10 ]]; then
+            echo "has_training_data=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_training_data=false" >> "$GITHUB_OUTPUT"
+            echo "> [!NOTE]" >> "$GITHUB_STEP_SUMMARY"
+            echo "> Pull request training skipped because only $line_count line(s) were found in the downloaded TSV, and the trainer requires at least 10." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   check-discussions-data:
-    if: ${{ always() && inputs.type == 'Discussions' && contains(fromJSON('["All", "Train Model", "Test Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.download-discussions.result) }}
+    if: ${{ always() && contains(fromJSON('["All", "Discussions"]'), inputs.type) && contains(fromJSON('["All", "Train Model", "Test Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.download-discussions.result) }}
     runs-on: ubuntu-latest
     permissions: {}
     needs: download-discussions
@@ -138,7 +194,7 @@ jobs:
           fi
 
   train-discussions:
-    if: ${{ always() && inputs.type == 'Discussions' && contains(fromJSON('["All", "Train Model"]'), inputs.steps) && needs.check-discussions-data.outputs.has_training_data == 'true' && contains(fromJSON('["success", "skipped"]'), needs.download-discussions.result) }}
+    if: ${{ always() && contains(fromJSON('["All", "Discussions"]'), inputs.type) && contains(fromJSON('["All", "Train Model"]'), inputs.steps) && needs.check-discussions-data.outputs.has_training_data == 'true' && contains(fromJSON('["success", "skipped"]'), needs.download-discussions.result) }}
     runs-on: ubuntu-latest
     permissions: {}
     needs:
@@ -153,10 +209,12 @@ jobs:
           model_cache_key: ${{ env.CACHE_KEY }}
 
   train-issues:
-    if: ${{ always() && contains(fromJSON('["Both", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Train Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.download-issues.result) }}
+    if: ${{ always() && contains(fromJSON('["All", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Train Model"]'), inputs.steps) && needs.check-issues-data.outputs.has_training_data == 'true' && contains(fromJSON('["success", "skipped"]'), needs.download-issues.result) }}
     runs-on: ubuntu-latest
     permissions: {}
-    needs: download-issues
+    needs:
+      - download-issues
+      - check-issues-data
     steps:
       - name: "Train Model for Issues"
         uses: dotnet/issue-labeler/train@main
@@ -166,10 +224,12 @@ jobs:
           model_cache_key: ${{ env.CACHE_KEY }}
 
   train-pulls:
-    if: ${{ always() && contains(fromJSON('["Both", "Pull Requests"]'), inputs.type) && contains(fromJSON('["All", "Train Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.download-pulls.result) }}
+    if: ${{ always() && contains(fromJSON('["All", "Pull Requests"]'), inputs.type) && contains(fromJSON('["All", "Train Model"]'), inputs.steps) && needs.check-pulls-data.outputs.has_training_data == 'true' && contains(fromJSON('["success", "skipped"]'), needs.download-pulls.result) }}
     runs-on: ubuntu-latest
     permissions: {}
-    needs: download-pulls
+    needs:
+      - download-pulls
+      - check-pulls-data
     steps:
       - name: "Train Model for Pull Requests"
         uses: dotnet/issue-labeler/train@main
@@ -179,11 +239,13 @@ jobs:
           model_cache_key: ${{ env.CACHE_KEY }}
 
   test-issues:
-    if: ${{ always() && contains(fromJSON('["Both", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Test Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.train-issues.result) }}
+    if: ${{ always() && contains(fromJSON('["All", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Test Model"]'), inputs.steps) && needs.check-issues-data.outputs.has_training_data == 'true' && contains(fromJSON('["success", "skipped"]'), needs.train-issues.result) }}
     runs-on: ubuntu-latest
     permissions:
       issues: read
-    needs: train-issues
+    needs:
+      - check-issues-data
+      - train-issues
     steps:
       - name: "Test Model for Issues"
         uses: dotnet/issue-labeler/test@main
@@ -200,7 +262,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   test-discussions:
-    if: ${{ always() && inputs.type == 'Discussions' && contains(fromJSON('["All", "Test Model"]'), inputs.steps) && needs.check-discussions-data.outputs.has_training_data == 'true' && contains(fromJSON('["success", "skipped"]'), needs.train-discussions.result) }}
+    if: ${{ always() && contains(fromJSON('["All", "Discussions"]'), inputs.type) && contains(fromJSON('["All", "Test Model"]'), inputs.steps) && needs.check-discussions-data.outputs.has_training_data == 'true' && contains(fromJSON('["success", "skipped"]'), needs.train-discussions.result) }}
     runs-on: ubuntu-latest
     permissions:
       discussions: read
@@ -223,11 +285,13 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   test-pulls:
-    if: ${{ always() && contains(fromJSON('["Both", "Pull Requests"]'), inputs.type) && contains(fromJSON('["All", "Test Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.train-pulls.result) }}
+    if: ${{ always() && contains(fromJSON('["All", "Pull Requests"]'), inputs.type) && contains(fromJSON('["All", "Test Model"]'), inputs.steps) && needs.check-pulls-data.outputs.has_training_data == 'true' && contains(fromJSON('["success", "skipped"]'), needs.train-pulls.result) }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
-    needs: train-pulls
+    needs:
+      - check-pulls-data
+      - train-pulls
     steps:
       - name: "Test Model for Pull Requests"
         uses: dotnet/issue-labeler/test@main

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -47,6 +47,7 @@ env:
   REPOSITORY: ${{ inputs.repository || github.repository }}
   LABEL_PREFIX: "area-"
   THRESHOLD: "0.40"
+  DISCUSSION_THRESHOLD: ${{ vars.ISSUE_LABELER_PREDICTION_THRESHOLD || '0.15' }}
   LIMIT: ${{ inputs.limit }}
   PAGE_SIZE: ${{ inputs.page_size }}
   PAGE_LIMIT: ${{ inputs.page_limit }}
@@ -277,7 +278,7 @@ jobs:
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
-          threshold: ${{ env.THRESHOLD }}
+          threshold: ${{ env.DISCUSSION_THRESHOLD }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}
           page_limit: ${{ env.PAGE_LIMIT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
             -p DebugType=none \
             -p ContainerBaseImage=${{ env.BASE_IMAGE }} \
             -p ContainerRegistry=ghcr.io \
-            -p ContainerImageTags="\"$IMAGE_TAG\"" \
+            -p ContainerImageTags=$IMAGE_TAG \
             -p ContainerRepository=${{ env.PREDICTOR_IMAGE_NAME }} \
             -p ContainerAuthors=${{ github.repository_owner }} \
             -p ContainerInformationUrl=${{ format('{0}/{1}', github.server_url, github.repository) }} \
@@ -94,7 +94,7 @@ jobs:
       - name: "Update the `predict` action to use the published image digest"
         run: |
           PREDICT_ACTION="predict/action.yml"
-          sed -i "s|ghcr.io/${{ env.PREDICTOR_IMAGE_NAME }}@.*|${{ needs.publish-predictor.outputs.published_image_digest }} # $IMAGE_TAG|" $PREDICT_ACTION
+          sed -i "s|^[[:space:]]*image:[[:space:]]*docker://ghcr\.io/.*$|  image: docker://${{ needs.publish-predictor.outputs.published_image_digest }} # $IMAGE_TAG|" $PREDICT_ACTION
 
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,10 @@ on:
   workflow_dispatch:
     inputs:
       image_tags:
-        description: "The optional semicolon separated list of tags to apply to the published Docker container image. The ref name is added automatically."
+        description: "Deprecated. Additional tags are currently ignored; only the sanitized ref name is published."
 
 env:
   BASE_IMAGE: mcr.microsoft.com/dotnet/runtime:9.0-noble-chiseled
-  IMAGE_TAGS: ${{ inputs.image_tags && format('{0};{1}', github.ref_name, inputs.image_tags) || github.ref_name }}
   PREDICTOR_IMAGE_NAME: ${{ github.repository }}/predictor
   PACKAGE_NAME_ESCAPED: issue-labeler%2Fpredictor
   GITHUB_API_PACKAGE_OWNER: /orgs/dotnet
@@ -39,6 +38,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "Compute sanitized image tag"
+        run: echo "IMAGE_TAG=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_ENV
+
       - name: "Publish Predictor"
         run: |
           dotnet publish IssueLabeler/src/Predictor/Predictor.csproj \
@@ -46,7 +48,7 @@ jobs:
             -p DebugType=none \
             -p ContainerBaseImage=${{ env.BASE_IMAGE }} \
             -p ContainerRegistry=ghcr.io \
-            -p ContainerImageTags='"${{ env.IMAGE_TAGS }}"' \
+            -p ContainerImageTags="\"$IMAGE_TAG\"" \
             -p ContainerRepository=${{ env.PREDICTOR_IMAGE_NAME }} \
             -p ContainerAuthors=${{ github.repository_owner }} \
             -p ContainerInformationUrl=${{ format('{0}/{1}', github.server_url, github.repository) }} \
@@ -63,7 +65,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               ${{ format('{0}/packages/container/{1}/versions', env.GITHUB_API_PACKAGE_OWNER, env.PACKAGE_NAME_ESCAPED) }} \
-            | jq -r '.[] | select(.metadata.container.tags[] == "${ github.ref_name }") | .name' \
+            | jq -r --arg tag "$IMAGE_TAG" '.[] | select(.metadata.container.tags[] == $tag) | .name' \
           `
           PUBLISHED_IMAGE_DIGEST=ghcr.io/${{ env.PREDICTOR_IMAGE_NAME }}@${DIGEST}
 
@@ -86,10 +88,13 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: "Compute sanitized image tag"
+        run: echo "IMAGE_TAG=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_ENV
+
       - name: "Update the `predict` action to use the published image digest"
         run: |
           PREDICT_ACTION="predict/action.yml"
-          sed -i "s|ghcr.io/${{ env.PREDICTOR_IMAGE_NAME }}@.*|${{ needs.publish-predictor.outputs.published_image_digest }} # ${{ env.IMAGE_TAGS }}|" $PREDICT_ACTION
+          sed -i "s|ghcr.io/${{ env.PREDICTOR_IMAGE_NAME }}@.*|${{ needs.publish-predictor.outputs.published_image_digest }} # $IMAGE_TAG|" $PREDICT_ACTION
 
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Compute sanitized image tag"
         id: compute
         run: |
-          IMAGE_TAG=$(printf '%s' '${{ github.ref_name }}' \
+          IMAGE_TAG=$(printf '%s' "${{ github.ref_name }}" \
             | tr '[:upper:]' '[:lower:]' \
             | tr '/[:space:]' '--' \
             | tr -cd '[:alnum:]_.-' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ name: "Release"
 
 on:
   workflow_dispatch:
-    inputs:
-      image_tags:
-        description: "Deprecated. Additional tags are currently ignored; only the sanitized ref name is published."
 
 env:
   BASE_IMAGE: mcr.microsoft.com/dotnet/runtime:9.0-noble-chiseled

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Compute sanitized image tag"
-        run: echo "IMAGE_TAG=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_ENV
+        run: |
+          IMAGE_TAG=$(printf '%s' '${{ github.ref_name }}' \
+            | tr '[:upper:]' '[:lower:]' \
+            | tr '/[:space:]' '--' \
+            | tr -cd '[:alnum:]_.-' \
+            | cut -c1-128)
+
+          if [[ -z "$IMAGE_TAG" ]]; then
+            IMAGE_TAG="ref-${{ github.run_number }}"
+          fi
+
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 
       - name: "Publish Predictor"
         run: |
@@ -89,7 +100,18 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Compute sanitized image tag"
-        run: echo "IMAGE_TAG=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_ENV
+        run: |
+          IMAGE_TAG=$(printf '%s' '${{ github.ref_name }}' \
+            | tr '[:upper:]' '[:lower:]' \
+            | tr '/[:space:]' '--' \
+            | tr -cd '[:alnum:]_.-' \
+            | cut -c1-128)
+
+          if [[ -z "$IMAGE_TAG" ]]; then
+            IMAGE_TAG="ref-${{ github.run_number }}"
+          fi
+
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 
       - name: "Update the `predict` action to use the published image digest"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,28 @@ env:
   GITHUB_API_PACKAGE_OWNER: /orgs/dotnet
 
 jobs:
+  compute-image-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.compute.outputs.image_tag }}
+    steps:
+      - name: "Compute sanitized image tag"
+        id: compute
+        run: |
+          IMAGE_TAG=$(printf '%s' '${{ github.ref_name }}' \
+            | tr '[:upper:]' '[:lower:]' \
+            | tr '/[:space:]' '--' \
+            | tr -cd '[:alnum:]_.-' \
+            | cut -c1-128)
+
+          if [[ -z "$IMAGE_TAG" ]]; then
+            IMAGE_TAG="ref-${{ github.run_number }}"
+          fi
+
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
   publish-predictor:
+    needs: compute-image-tag
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,20 +56,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Compute sanitized image tag"
-        run: |
-          IMAGE_TAG=$(printf '%s' '${{ github.ref_name }}' \
-            | tr '[:upper:]' '[:lower:]' \
-            | tr '/[:space:]' '--' \
-            | tr -cd '[:alnum:]_.-' \
-            | cut -c1-128)
-
-          if [[ -z "$IMAGE_TAG" ]]; then
-            IMAGE_TAG="ref-${{ github.run_number }}"
-          fi
-
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-
       - name: "Publish Predictor"
         run: |
           dotnet publish IssueLabeler/src/Predictor/Predictor.csproj \
@@ -56,7 +63,7 @@ jobs:
             -p DebugType=none \
             -p ContainerBaseImage=${{ env.BASE_IMAGE }} \
             -p ContainerRegistry=ghcr.io \
-            -p ContainerImageTags=$IMAGE_TAG \
+            -p ContainerImageTags=${{ needs.compute-image-tag.outputs.image_tag }} \
             -p ContainerRepository=${{ env.PREDICTOR_IMAGE_NAME }} \
             -p ContainerAuthors=${{ github.repository_owner }} \
             -p ContainerInformationUrl=${{ format('{0}/{1}', github.server_url, github.repository) }} \
@@ -73,7 +80,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               ${{ format('{0}/packages/container/{1}/versions', env.GITHUB_API_PACKAGE_OWNER, env.PACKAGE_NAME_ESCAPED) }} \
-            | jq -r --arg tag "$IMAGE_TAG" '.[] | select(.metadata.container.tags[] == $tag) | .name' \
+            | jq -r --arg tag "${{ needs.compute-image-tag.outputs.image_tag }}" '.[] | select(.metadata.container.tags[] == $tag) | .name' \
           `
           PUBLISHED_IMAGE_DIGEST=ghcr.io/${{ env.PREDICTOR_IMAGE_NAME }}@${DIGEST}
 
@@ -88,7 +95,9 @@ jobs:
 
   update-predictor-action:
     runs-on: ubuntu-latest
-    needs: publish-predictor
+    needs:
+      - compute-image-tag
+      - publish-predictor
     permissions:
       contents: write
       packages: read
@@ -96,24 +105,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: "Compute sanitized image tag"
-        run: |
-          IMAGE_TAG=$(printf '%s' '${{ github.ref_name }}' \
-            | tr '[:upper:]' '[:lower:]' \
-            | tr '/[:space:]' '--' \
-            | tr -cd '[:alnum:]_.-' \
-            | cut -c1-128)
-
-          if [[ -z "$IMAGE_TAG" ]]; then
-            IMAGE_TAG="ref-${{ github.run_number }}"
-          fi
-
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-
       - name: "Update the `predict` action to use the published image digest"
         run: |
           PREDICT_ACTION="predict/action.yml"
-          sed -i "s|^[[:space:]]*image:[[:space:]]*docker://ghcr\.io/.*$|  image: docker://${{ needs.publish-predictor.outputs.published_image_digest }} # $IMAGE_TAG|" $PREDICT_ACTION
+          sed -i "s|^[[:space:]]*image:[[:space:]]*docker://ghcr\.io/.*$|  image: docker://${{ needs.publish-predictor.outputs.published_image_digest }} # ${{ needs.compute-image-tag.outputs.image_tag }}|" $PREDICT_ACTION
 
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"

--- a/IssueLabeler/src/Common/ModelType.cs
+++ b/IssueLabeler/src/Common/ModelType.cs
@@ -4,5 +4,6 @@
 public enum ModelType
 {
     Issue = 1,
-    PullRequest = 2
+    PullRequest = 2,
+    Discussion = 3
 }

--- a/IssueLabeler/src/Downloader/Args.cs
+++ b/IssueLabeler/src/Downloader/Args.cs
@@ -44,7 +44,7 @@ public struct Args
 
             Optional arguments:
               --issues-limit          Maximum number of issues to download. Defaults to: No limit.
-                            --discussions-limit     Maximum number of discussions to download. Defaults to: No limit.
+              --discussions-limit     Maximum number of discussions to download. Defaults to: No limit.
               --pulls-limit           Maximum number of pull requests to download. Defaults to: No limit.
               --page-size             Number of items per page in GitHub API requests.
               --page-limit            Maximum number of pages to retrieve.

--- a/IssueLabeler/src/Downloader/Args.cs
+++ b/IssueLabeler/src/Downloader/Args.cs
@@ -10,6 +10,8 @@ public struct Args
     public List<string> Repos { get; set; }
     public string? IssuesDataPath { get; set; }
     public int? IssuesLimit { get; set; }
+    public string? DiscussionsDataPath { get; set; }
+    public int? DiscussionsLimit { get; set; }
     public string? PullsDataPath { get; set; }
     public int? PullsLimit { get; set; }
     public int? PageSize { get; set; }
@@ -34,11 +36,15 @@ public struct Args
             Required for downloading issue data:
               --issues-data           Path for issue data file to create (TSV file).
 
+                        Required for downloading discussion data:
+                            --discussions-data      Path for discussion data file to create (TSV file).
+
             Required for downloading pull request data:
               --pulls-data            Path for pull request data file to create (TSV file).
 
             Optional arguments:
               --issues-limit          Maximum number of issues to download. Defaults to: No limit.
+                            --discussions-limit     Maximum number of discussions to download. Defaults to: No limit.
               --pulls-limit           Maximum number of pull requests to download. Defaults to: No limit.
               --page-size             Number of items per page in GitHub API requests.
               --page-limit            Maximum number of pages to retrieve.
@@ -114,6 +120,22 @@ public struct Args
                     argsData.IssuesLimit = IssuesLimit;
                     break;
 
+                case "--discussions-data":
+                    if (!argUtils.TryGetPath("--discussions-data", out string? discussionsDataPath))
+                    {
+                        return null;
+                    }
+                    argsData.DiscussionsDataPath = discussionsDataPath;
+                    break;
+
+                case "--discussions-limit":
+                    if (!argUtils.TryGetInt("--discussions-limit", out int? discussionsLimit))
+                    {
+                        return null;
+                    }
+                    argsData.DiscussionsLimit = discussionsLimit;
+                    break;
+
                 case "--pulls-data":
                     if (!argUtils.TryGetPath("--pulls-data", out string? PullsDataPath))
                     {
@@ -165,7 +187,7 @@ public struct Args
         }
 
         if (argsData.Org is null || argsData.Repos is null || argsData.LabelPredicate is null ||
-            (argsData.IssuesDataPath is null && argsData.PullsDataPath is null))
+            (argsData.IssuesDataPath is null && argsData.DiscussionsDataPath is null && argsData.PullsDataPath is null))
         {
             ShowUsage(null, action);
             return null;

--- a/IssueLabeler/src/Downloader/Args.cs
+++ b/IssueLabeler/src/Downloader/Args.cs
@@ -36,8 +36,8 @@ public struct Args
             Required for downloading issue data:
               --issues-data           Path for issue data file to create (TSV file).
 
-                        Required for downloading discussion data:
-                            --discussions-data      Path for discussion data file to create (TSV file).
+            Required for downloading discussion data:
+              --discussions-data      Path for discussion data file to create (TSV file).
 
             Required for downloading pull request data:
               --pulls-data            Path for pull request data file to create (TSV file).

--- a/IssueLabeler/src/Downloader/Downloader.cs
+++ b/IssueLabeler/src/Downloader/Downloader.cs
@@ -22,6 +22,12 @@ if (!string.IsNullOrEmpty(argsData.IssuesDataPath))
     tasks.Add(Task.Run(() => DownloadIssues(argsData.IssuesDataPath)));
 }
 
+if (!string.IsNullOrEmpty(argsData.DiscussionsDataPath))
+{
+    EnsureOutputDirectory(argsData.DiscussionsDataPath);
+    tasks.Add(Task.Run(() => DownloadDiscussions(argsData.DiscussionsDataPath)));
+}
+
 if (!string.IsNullOrEmpty(argsData.PullsDataPath))
 {
     EnsureOutputDirectory(argsData.PullsDataPath);
@@ -75,6 +81,34 @@ async Task DownloadPullRequests(string outputPath)
                                                                     argsData.Retries, argsData.ExcludedAuthors, action, argsData.Verbose))
         {
             writer.WriteLine(FormatPullRequestRecord(result.Label, result.PullRequest.Title, result.PullRequest.Body, result.PullRequest.FileNames, result.PullRequest.FolderNames));
+
+            if (++perFlushCount == 100)
+            {
+                writer.Flush();
+                perFlushCount = 0;
+            }
+        }
+    }
+
+    writer.Close();
+}
+
+async Task DownloadDiscussions(string outputPath)
+{
+    action.WriteInfo($"Discussions Data Path: {outputPath}");
+
+    byte perFlushCount = 0;
+
+    using StreamWriter writer = new StreamWriter(outputPath);
+    writer.WriteLine(FormatIssueRecord("Label", "Title", "Body"));
+
+    foreach (var repo in argsData.Repos)
+    {
+        await foreach (var result in GitHubApi.DownloadDiscussions(argsData.GitHubToken, argsData.Org, repo, argsData.LabelPredicate,
+                                                                   argsData.DiscussionsLimit, argsData.PageSize, argsData.PageLimit,
+                                                                   argsData.Retries, argsData.ExcludedAuthors, action, argsData.Verbose))
+        {
+            writer.WriteLine(FormatIssueRecord(result.Label, result.Discussion.Title, result.Discussion.Body));
 
             if (++perFlushCount == 100)
             {

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -139,6 +139,28 @@ public class GitHubApi
     }
 
     /// <summary>
+    /// Downloads discussions from a GitHub repository, filtering them by label and other criteria.
+    /// </summary>
+    public static async IAsyncEnumerable<(Discussion Discussion, string Label)> DownloadDiscussions(
+        string githubToken,
+        string org,
+        string repo,
+        Predicate<string> labelPredicate,
+        int? discussionsLimit,
+        int? pageSize,
+        int? pageLimit,
+        int[] retries,
+        string[]? excludedAuthors,
+        ICoreService action,
+        bool verbose = false)
+    {
+        await foreach (var item in DownloadDiscussionItems(githubToken, org, repo, labelPredicate, discussionsLimit, pageSize ?? 25, pageLimit ?? 1000, retries, excludedAuthors, action, verbose))
+        {
+            yield return (item.Item, item.Label);
+        }
+    }
+
+    /// <summary>
     /// Downloads items from a GitHub repository, filtering them by label and other criteria.
     /// </summary>
     /// <typeparam name="T"></typeparam>
@@ -298,6 +320,192 @@ public class GitHubApi
             }
         }
         while (!finished);
+    }
+
+    private static async IAsyncEnumerable<(Discussion Item, string Label)> DownloadDiscussionItems(
+        string githubToken,
+        string org,
+        string repo,
+        Predicate<string> labelPredicate,
+        int? itemLimit,
+        int pageSize,
+        int pageLimit,
+        int[] retries,
+        string[]? excludedAuthors,
+        ICoreService action,
+        bool verbose)
+    {
+        pageSize = Math.Min(pageSize, 100);
+
+        int pageNumber = 0;
+        string? after = null;
+        bool hasNextPage = true;
+        int loadedCount = 0;
+        int includedCount = 0;
+        int? totalCount = null;
+        byte retry = 0;
+        bool finished = false;
+
+        do
+        {
+            action.WriteInfo($"Downloading Discussions page {pageNumber + 1} from {org}/{repo}...{(retry > 0 ? $" (retry {retry} of {retries.Length}) " : "")}{(after is not null ? $" (cursor: '{after}')" : "")}");
+
+            Page<Discussion> page;
+
+            try
+            {
+                page = await GetDiscussionsPage(githubToken, org, repo, pageSize, after);
+            }
+            catch (Exception ex) when (
+                ex is HttpIOException ||
+                ex is HttpRequestException ||
+                ex is GraphQLHttpRequestException ||
+                ex is TaskCanceledException
+            )
+            {
+                action.WriteInfo($"Exception caught during query.\n  {ex.Message}");
+
+                if (retry >= retries.Length - 1)
+                {
+                    await action.WriteStatusAsync($"Retry limit of {retries.Length} reached. Aborting.");
+
+                    throw new ApplicationException($"""
+                        Retry limit of {retries.Length} reached. Aborting.
+
+                        {ex.Message}
+
+                        Total Downloaded: {totalCount}
+                        Applicable for Training: {loadedCount}
+                        Page Number: {pageNumber}
+                        """);
+                }
+
+                await action.WriteStatusAsync($"Waiting {retries[retry]} seconds before retry {retry + 1} of {retries.Length}...");
+                await Task.Delay(retries[retry] * 1000);
+                retry++;
+
+                continue;
+            }
+
+            if (after == page.EndCursor)
+            {
+                action.WriteError($"Paging did not progress. Cursor: '{after}'. Aborting.");
+                break;
+            }
+
+            pageNumber++;
+            after = page.EndCursor;
+            hasNextPage = page.HasNextPage;
+            loadedCount += page.Nodes.Length;
+            totalCount ??= page.TotalCount;
+            retry = 0;
+
+            foreach (Discussion item in page.Nodes)
+            {
+                if (excludedAuthors is not null && item.Author?.Login is not null && excludedAuthors.Contains(item.Author.Login, StringComparer.InvariantCultureIgnoreCase))
+                {
+                    if (verbose) action.WriteInfo($"Discussion {org}/{repo}#{item.Number} - Excluded from output. Author '{item.Author.Login}' is in excluded list.");
+                    continue;
+                }
+
+                if (item.Labels.HasNextPage)
+                {
+                    if (verbose) action.WriteInfo($"Discussion {org}/{repo}#{item.Number} - Excluded from output. Not all labels were loaded.");
+                    continue;
+                }
+
+                string[] labels = Array.FindAll(item.LabelNames, labelPredicate);
+                if (labels.Length != 1)
+                {
+                    if (verbose) action.WriteInfo($"Discussion {org}/{repo}#{item.Number} - Excluded from output. {labels.Length} applicable labels found.");
+                    continue;
+                }
+
+                if (verbose) action.WriteInfo($"Discussion {org}/{repo}#{item.Number} - Included in output. Applicable label: '{labels[0]}'.");
+
+                yield return (item, labels[0]);
+
+                includedCount++;
+
+                if (itemLimit.HasValue && includedCount >= itemLimit)
+                {
+                    break;
+                }
+            }
+
+            finished = (!hasNextPage || pageNumber >= pageLimit || (itemLimit.HasValue && includedCount >= itemLimit));
+
+            await action.WriteStatusAsync(
+                $"Items to Include: {includedCount} (limit: {(itemLimit.HasValue ? itemLimit : "none")}) | " +
+                $"Items Downloaded: {loadedCount} (total: {totalCount}) | " +
+                $"Pages Downloaded: {pageNumber} (limit: {pageLimit})");
+
+            if (finished)
+            {
+                action.Summary.AddPersistent(summary => {
+                    summary.AddMarkdownHeading($"Finished Downloading Discussions from {org}/{repo}", 2);
+                    summary.AddMarkdownList([
+                        $"Items to Include: {includedCount} (limit: {(itemLimit.HasValue ? itemLimit : "none")})",
+                        $"Items Downloaded: {loadedCount} (total: {totalCount})",
+                        $"Pages Downloaded: {pageNumber} (limit: {pageLimit})"
+                    ]);
+                });
+            }
+        }
+        while (!finished);
+    }
+
+    private static async Task<Page<Discussion>> GetDiscussionsPage(string githubToken, string org, string repo, int pageSize, string? after)
+    {
+        GraphQLHttpClient client = GetGraphQLClient(githubToken);
+
+        GraphQLRequest query = new GraphQLRequest
+        {
+            Query = $$"""
+                query ($owner: String!, $repo: String!, $after: String) {
+                    repository (owner: $owner, name: $repo) {
+                        result:discussions (after: $after, first: {{pageSize}}, orderBy: {field: CREATED_AT, direction: DESC}) {
+                            nodes {
+                                number
+                                id
+                                title
+                                author { login }
+                                body: bodyText
+                                labels (first: 25) {
+                                    nodes { name }
+                                    pageInfo { hasNextPage }
+                                }
+                            }
+                            pageInfo {
+                                hasNextPage
+                                endCursor
+                            }
+                            totalCount
+                        }
+                    }
+                }
+                """,
+            Variables = new
+            {
+                Owner = org,
+                Repo = repo,
+                After = after
+            }
+        };
+
+        var response = await client.SendQueryAsync<RepositoryQuery<Page<Discussion>>>(query);
+
+        if (response.Errors?.Any() ?? false)
+        {
+            string errors = string.Join("\n\n", response.Errors.Select((e, i) => $"{i + 1}. {e.Message}").ToArray());
+            throw new ApplicationException($"GraphQL request returned errors.\n\n{errors}");
+        }
+        else if (response.Data is null || response.Data.Repository is null || response.Data.Repository.Result is null)
+        {
+            throw new ApplicationException("GraphQL response did not include the repository result data");
+        }
+
+        return response.Data.Repository.Result;
     }
 
     /// <summary>

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -667,9 +667,9 @@ public class GitHubApi
         return null;
     }
 
-    private static async Task<string?> GetOrCreateLabelNodeId(HttpClient restClient, string org, string repo, string labelName)
+    private static async Task<string?> GetOrCreateLabelNodeId(HttpClient restClient, string org, string repo, string labelName, ICoreService action)
     {
-        string cacheKey = $"{org}/{repo}/{labelName}";
+        string cacheKey = $"{org.ToLowerInvariant()}/{repo.ToLowerInvariant()}/{labelName.ToLowerInvariant()}";
         if (_labelNodeIdCache.TryGetValue(cacheKey, out string? cached))
             return cached;
 
@@ -685,7 +685,10 @@ public class GitHubApi
         }
 
         if ((int)getResponse.StatusCode != 404)
+        {
+            action.WriteInfo($"[Label] Unexpected status {(int)getResponse.StatusCode} ({getResponse.ReasonPhrase}) when fetching label '{labelName}' from {org}/{repo}.");
             return null;
+        }
 
         // Label doesn't exist — create it
         var createResponse = await restClient.PostAsJsonAsync(
@@ -712,14 +715,19 @@ public class GitHubApi
                 if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
                 return nodeId;
             }
+
+            action.WriteInfo($"[Label] Unexpected status {(int)refetchResponse.StatusCode} ({refetchResponse.ReasonPhrase}) when refetching label '{labelName}' from {org}/{repo} after a create race.");
+            return null;
         }
+
+        action.WriteInfo($"[Label] Unexpected status {(int)createResponse.StatusCode} ({createResponse.ReasonPhrase}) when creating label '{labelName}' in {org}/{repo}.");
 
         return null;
     }
 
-    private static async Task<string?> GetLabelNodeId(HttpClient restClient, string org, string repo, string labelName)
+    private static async Task<string?> GetLabelNodeId(HttpClient restClient, string org, string repo, string labelName, ICoreService action)
     {
-        string cacheKey = $"{org}/{repo}/{labelName}";
+        string cacheKey = $"{org.ToLowerInvariant()}/{repo.ToLowerInvariant()}/{labelName.ToLowerInvariant()}";
         if (_labelNodeIdCache.TryGetValue(cacheKey, out string? cached))
             return cached;
 
@@ -727,7 +735,11 @@ public class GitHubApi
             $"https://api.github.com/repos/{org}/{repo}/labels/{Uri.EscapeDataString(labelName)}");
 
         if (!response.IsSuccessStatusCode)
+        {
+            if ((int)response.StatusCode != 404)
+                action.WriteInfo($"[Label] Unexpected status {(int)response.StatusCode} ({response.ReasonPhrase}) when fetching label '{labelName}' from {org}/{repo}.");
             return null;
+        }
 
         var label = await response.Content.ReadFromJsonAsync<JsonElement>();
         string? nodeId = label.GetProperty("node_id").GetString();
@@ -747,7 +759,7 @@ public class GitHubApi
         var restClient = GetRestClient(githubToken);
         var graphqlClient = GetGraphQLClient(githubToken);
 
-        string? labelNodeId = await GetOrCreateLabelNodeId(restClient, org, repo, labelName);
+        string? labelNodeId = await GetOrCreateLabelNodeId(restClient, org, repo, labelName, action);
         if (labelNodeId is null)
             return $"Failed to resolve or create label '{labelName}'.";
 
@@ -810,7 +822,7 @@ public class GitHubApi
         var graphqlClient = GetGraphQLClient(githubToken);
 
         // If the label doesn't exist there's nothing to remove
-        string? labelNodeId = await GetLabelNodeId(restClient, org, repo, labelName);
+        string? labelNodeId = await GetLabelNodeId(restClient, org, repo, labelName, action);
         if (labelNodeId is null) return null;
 
         var mutation = new GraphQLRequest

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -690,64 +690,6 @@ public class GitHubApi
         return null;
     }
 
-    private static async Task<string?> GetOrCreateLabelNodeId(HttpClient restClient, string org, string repo, string labelName, ICoreService action)
-    {
-        string cacheKey = $"{org.ToLowerInvariant()}/{repo.ToLowerInvariant()}/{labelName.ToLowerInvariant()}";
-        if (_labelNodeIdCache.TryGetValue(cacheKey, out string? cached))
-            return cached;
-
-        var getResponse = await restClient.GetAsync(
-            $"https://api.github.com/repos/{org}/{repo}/labels/{Uri.EscapeDataString(labelName)}");
-
-        if (getResponse.IsSuccessStatusCode)
-        {
-            var label = await getResponse.Content.ReadFromJsonAsync<JsonElement>();
-            string? nodeId = label.TryGetProperty("node_id", out var nodeIdProp) ? nodeIdProp.GetString() : null;
-            if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
-            return nodeId;
-        }
-
-        if ((int)getResponse.StatusCode != 404)
-        {
-            action.WriteInfo($"[Label] Unexpected status {(int)getResponse.StatusCode} ({getResponse.ReasonPhrase}) when fetching label '{labelName}' from {org}/{repo}.");
-            return null;
-        }
-
-        // Label doesn't exist — create it
-        var createResponse = await restClient.PostAsJsonAsync(
-            $"https://api.github.com/repos/{org}/{repo}/labels",
-            new { name = labelName, color = "ededed" });
-
-        if (createResponse.IsSuccessStatusCode)
-        {
-            var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
-            string? nodeId = created.TryGetProperty("node_id", out var createdNodeIdProp) ? createdNodeIdProp.GetString() : null;
-            if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
-            return nodeId;
-        }
-
-        if ((int)createResponse.StatusCode == 422)
-        {
-            // Race condition: another run created the label concurrently; re-fetch it
-            var refetchResponse = await restClient.GetAsync(
-                $"https://api.github.com/repos/{org}/{repo}/labels/{Uri.EscapeDataString(labelName)}");
-            if (refetchResponse.IsSuccessStatusCode)
-            {
-                var label = await refetchResponse.Content.ReadFromJsonAsync<JsonElement>();
-                string? nodeId = label.TryGetProperty("node_id", out var refetchNodeIdProp) ? refetchNodeIdProp.GetString() : null;
-                if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
-                return nodeId;
-            }
-
-            action.WriteInfo($"[Label] Unexpected status {(int)refetchResponse.StatusCode} ({refetchResponse.ReasonPhrase}) when refetching label '{labelName}' from {org}/{repo} after a create race.");
-            return null;
-        }
-
-        action.WriteInfo($"[Label] Unexpected status {(int)createResponse.StatusCode} ({createResponse.ReasonPhrase}) when creating label '{labelName}' in {org}/{repo}.");
-
-        return null;
-    }
-
     private static async Task<string?> GetLabelNodeId(HttpClient restClient, string org, string repo, string labelName, ICoreService action)
     {
         string cacheKey = $"{org.ToLowerInvariant()}/{repo.ToLowerInvariant()}/{labelName.ToLowerInvariant()}";

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -782,10 +782,6 @@ public class GitHubApi
         var restClient = GetRestClient(githubToken);
         var graphqlClient = GetGraphQLClient(githubToken);
 
-        string? labelNodeId = await GetOrCreateLabelNodeId(restClient, org, repo, labelName, action);
-        if (labelNodeId is null)
-            return $"Failed to resolve or create label '{labelName}'.";
-
         var mutation = new GraphQLRequest
         {
             Query = """
@@ -794,14 +790,28 @@ public class GitHubApi
                         clientMutationId
                     }
                 }
-                """,
-            Variables = new { labelableId = discussionNodeId, labelIds = new[] { labelNodeId } }
+                """
         };
 
         byte retry = 0;
 
         while (retry < retries.Length)
         {
+            string? labelNodeId = await GetLabelNodeId(restClient, org, repo, labelName, action);
+            if (labelNodeId is null)
+            {
+                action.WriteInfo($"""
+                    [Discussion] Failed to apply label '{labelName}'.
+                        Label does not exist in {org}/{repo}.
+                        {(retry < retries.Length - 1 ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    """);
+                int labelDelay = Math.Min(retries[retry++], MaxLabelDelaySeconds);
+                await Task.Delay(labelDelay * 1000);
+                continue;
+            }
+
+            mutation.Variables = new { labelableId = discussionNodeId, labelIds = new[] { labelNodeId } };
+
             try
             {
                 var response = await graphqlClient.SendMutationAsync<object>(mutation);

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -7,6 +7,7 @@ using GraphQL.Client.Http;
 using GraphQL.Client.Serializer.SystemTextJson;
 using System.Collections.Concurrent;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 namespace GitHubClient;
 
@@ -569,5 +570,276 @@ public class GitHubApi
         }
 
         return $"Failed to remove label '{label}' after {retries.Length} retries.";
+    }
+
+    /// <summary>
+    /// Gets a discussion from a GitHub repository using GraphQL.
+    /// </summary>
+    public static async Task<Discussion?> GetDiscussion(string githubToken, string org, string repo, ulong number, int[] retries, ICoreService action, bool verbose)
+    {
+        GraphQLHttpClient client = GetGraphQLClient(githubToken);
+
+        GraphQLRequest query = new()
+        {
+            Query = """
+                query ($owner: String!, $repo: String!, $number: Int!) {
+                    repository (owner: $owner, name: $repo) {
+                        result:discussion (number: $number) {
+                            number
+                            id
+                            title
+                            author { login }
+                            body: bodyText
+                            labels (first: 25) {
+                                nodes { name }
+                                pageInfo { hasNextPage }
+                            }
+                        }
+                    }
+                }
+                """,
+            Variables = new { Owner = org, Repo = repo, Number = number }
+        };
+
+        byte retry = 0;
+
+        while (retry < retries.Length)
+        {
+            try
+            {
+                var response = await client.SendQueryAsync<RepositoryQuery<Discussion>>(query);
+
+                if (!(response.Errors?.Any() ?? false) && response.Data?.Repository?.Result is not null)
+                    return response.Data.Repository.Result;
+
+                if (response.Errors?.Any() ?? false)
+                {
+                    if (response.Errors.Any(e => e.Message.StartsWith("API rate limit exceeded")))
+                    {
+                        action.WriteInfo($"""
+                            [Discussion {org}/{repo}#{number}] Failed to retrieve data.
+                                Rate limit has been reached.
+                                {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                            """);
+                    }
+                    else
+                    {
+                        string errors = string.Join("\n\n", response.Errors.Select((e, i) => $"{i + 1}. {e.Message}").ToArray());
+                        action.WriteInfo($"""
+                            [Discussion {org}/{repo}#{number}] Failed to retrieve data.
+                                GraphQL request returned errors:
+
+                                {errors}
+                            """);
+                        return null;
+                    }
+                }
+                else
+                {
+                    action.WriteInfo($"""
+                        [Discussion {org}/{repo}#{number}] Failed to retrieve data.
+                            GraphQL response did not include the repository result data.
+                        """);
+                    return null;
+                }
+            }
+            catch (Exception ex) when (
+                ex is HttpIOException ||
+                ex is HttpRequestException ||
+                ex is GraphQLHttpRequestException ||
+                ex is TaskCanceledException
+            )
+            {
+                action.WriteInfo($"""
+                    [Discussion {org}/{repo}#{number}] Failed to retrieve data.
+                        Exception caught during query.
+
+                        {ex.Message}
+
+                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    """);
+            }
+
+            await Task.Delay(retries[retry++] * 1000);
+        }
+
+        return null;
+    }
+
+    private static async Task<string?> GetOrCreateLabelNodeId(HttpClient restClient, string org, string repo, string labelName)
+    {
+        var getResponse = await restClient.GetAsync(
+            $"https://api.github.com/repos/{org}/{repo}/labels/{Uri.EscapeDataString(labelName)}");
+
+        if (getResponse.IsSuccessStatusCode)
+        {
+            var label = await getResponse.Content.ReadFromJsonAsync<JsonElement>();
+            return label.GetProperty("node_id").GetString();
+        }
+
+        if ((int)getResponse.StatusCode != 404)
+            return null;
+
+        // Label doesn't exist — create it
+        var createResponse = await restClient.PostAsJsonAsync(
+            $"https://api.github.com/repos/{org}/{repo}/labels",
+            new { name = labelName, color = "ededed" });
+
+        if (createResponse.IsSuccessStatusCode)
+        {
+            var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+            return created.GetProperty("node_id").GetString();
+        }
+
+        if ((int)createResponse.StatusCode == 422)
+        {
+            // Race condition: another run created the label concurrently; re-fetch it
+            var refetchResponse = await restClient.GetAsync(
+                $"https://api.github.com/repos/{org}/{repo}/labels/{Uri.EscapeDataString(labelName)}");
+            if (refetchResponse.IsSuccessStatusCode)
+            {
+                var label = await refetchResponse.Content.ReadFromJsonAsync<JsonElement>();
+                return label.GetProperty("node_id").GetString();
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<string?> GetLabelNodeId(HttpClient restClient, string org, string repo, string labelName)
+    {
+        var response = await restClient.GetAsync(
+            $"https://api.github.com/repos/{org}/{repo}/labels/{Uri.EscapeDataString(labelName)}");
+
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        var label = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return label.GetProperty("node_id").GetString();
+    }
+
+    /// <summary>
+    /// Adds a label to a discussion in a GitHub repository via GraphQL.
+    /// Creates the label in the repository if it does not yet exist.
+    /// </summary>
+    public static async Task<string?> AddLabelToDiscussion(
+        string githubToken, string org, string repo,
+        string discussionNodeId, string labelName,
+        int[] retries, ICoreService action)
+    {
+        var restClient = GetRestClient(githubToken);
+        var graphqlClient = GetGraphQLClient(githubToken);
+
+        string? labelNodeId = await GetOrCreateLabelNodeId(restClient, org, repo, labelName);
+        if (labelNodeId is null)
+            return $"Failed to resolve or create label '{labelName}'.";
+
+        var mutation = new GraphQLRequest
+        {
+            Query = """
+                mutation($labelableId: ID!, $labelIds: [ID!]!) {
+                    addLabelsToLabelable(input: { labelableId: $labelableId, labelIds: $labelIds }) {
+                        clientMutationId
+                    }
+                }
+                """,
+            Variables = new { labelableId = discussionNodeId, labelIds = new[] { labelNodeId } }
+        };
+
+        byte retry = 0;
+
+        while (retry < retries.Length)
+        {
+            try
+            {
+                var response = await graphqlClient.SendMutationAsync<object>(mutation);
+                if (!(response.Errors?.Any() ?? false)) return null;
+
+                action.WriteInfo($"""
+                    [Discussion] Failed to apply label '{labelName}'.
+                        {string.Join("; ", response.Errors!.Select(e => e.Message))}
+                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    """);
+            }
+            catch (Exception ex) when (
+                ex is HttpIOException ||
+                ex is HttpRequestException ||
+                ex is GraphQLHttpRequestException ||
+                ex is TaskCanceledException)
+            {
+                action.WriteInfo($"""
+                    [Discussion] Failed to apply label '{labelName}'.
+                        {ex.Message}
+                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    """);
+            }
+
+            int delay = Math.Min(retries[retry++], MaxLabelDelaySeconds);
+            await Task.Delay(delay * 1000);
+        }
+
+        return $"Failed to apply label '{labelName}' after {retries.Length} retries.";
+    }
+
+    /// <summary>
+    /// Removes a label from a discussion in a GitHub repository via GraphQL.
+    /// </summary>
+    public static async Task<string?> RemoveLabelFromDiscussion(
+        string githubToken, string org, string repo,
+        string discussionNodeId, string labelName,
+        int[] retries, ICoreService action)
+    {
+        var restClient = GetRestClient(githubToken);
+        var graphqlClient = GetGraphQLClient(githubToken);
+
+        // If the label doesn't exist there's nothing to remove
+        string? labelNodeId = await GetLabelNodeId(restClient, org, repo, labelName);
+        if (labelNodeId is null) return null;
+
+        var mutation = new GraphQLRequest
+        {
+            Query = """
+                mutation($labelableId: ID!, $labelIds: [ID!]!) {
+                    removeLabelsFromLabelable(input: { labelableId: $labelableId, labelIds: $labelIds }) {
+                        clientMutationId
+                    }
+                }
+                """,
+            Variables = new { labelableId = discussionNodeId, labelIds = new[] { labelNodeId } }
+        };
+
+        byte retry = 0;
+
+        while (retry < retries.Length)
+        {
+            try
+            {
+                var response = await graphqlClient.SendMutationAsync<object>(mutation);
+                if (!(response.Errors?.Any() ?? false)) return null;
+
+                action.WriteInfo($"""
+                    [Discussion] Failed to remove label '{labelName}'.
+                        {string.Join("; ", response.Errors!.Select(e => e.Message))}
+                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    """);
+            }
+            catch (Exception ex) when (
+                ex is HttpIOException ||
+                ex is HttpRequestException ||
+                ex is GraphQLHttpRequestException ||
+                ex is TaskCanceledException)
+            {
+                action.WriteInfo($"""
+                    [Discussion] Failed to remove label '{labelName}'.
+                        {ex.Message}
+                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    """);
+            }
+
+            int delay = Math.Min(retries[retry++], MaxLabelDelaySeconds);
+            await Task.Delay(delay * 1000);
+        }
+
+        return $"Failed to remove label '{labelName}' after {retries.Length} retries.";
     }
 }

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -17,6 +17,7 @@ public class GitHubApi
     private static ConcurrentDictionary<string, HttpClient> _restClients = new();
     private static ConcurrentDictionary<string, string> _labelNodeIdCache = new();
     private const int MaxLabelDelaySeconds = 30;
+    private const int MaxLabelNodeIdCacheEntries = 256;
 
     private static string GetRetryMessage(byte retry, int[] retries) =>
         retry + 1 < retries.Length
@@ -806,7 +807,7 @@ public class GitHubApi
     /// <summary>
     /// Gets a discussion from a GitHub repository using GraphQL.
     /// </summary>
-    public static async Task<Discussion?> GetDiscussion(string githubToken, string org, string repo, ulong number, int[] retries, ICoreService action, bool verbose)
+    public static async Task<Discussion?> GetDiscussion(string githubToken, string org, string repo, ulong number, int[] retries, ICoreService action)
     {
         GraphQLHttpClient client = GetGraphQLClient(githubToken);
         int? graphQLNumber = GetGraphQLNumber("Discussion", org, repo, number, action);
@@ -925,7 +926,12 @@ public class GitHubApi
 
         var label = await response.Content.ReadFromJsonAsync<JsonElement>();
         string? nodeId = label.TryGetProperty("node_id", out var nodeIdProp) ? nodeIdProp.GetString() : null;
-        if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
+
+        if (nodeId is not null && _labelNodeIdCache.Count < MaxLabelNodeIdCacheEntries)
+        {
+            _labelNodeIdCache[cacheKey] = nodeId;
+        }
+
         return nodeId;
     }
 

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -702,7 +702,7 @@ public class GitHubApi
         if (getResponse.IsSuccessStatusCode)
         {
             var label = await getResponse.Content.ReadFromJsonAsync<JsonElement>();
-            string? nodeId = label.GetProperty("node_id").GetString();
+            string? nodeId = label.TryGetProperty("node_id", out var nodeIdProp) ? nodeIdProp.GetString() : null;
             if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
             return nodeId;
         }
@@ -721,7 +721,7 @@ public class GitHubApi
         if (createResponse.IsSuccessStatusCode)
         {
             var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
-            string? nodeId = created.GetProperty("node_id").GetString();
+            string? nodeId = created.TryGetProperty("node_id", out var createdNodeIdProp) ? createdNodeIdProp.GetString() : null;
             if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
             return nodeId;
         }
@@ -734,7 +734,7 @@ public class GitHubApi
             if (refetchResponse.IsSuccessStatusCode)
             {
                 var label = await refetchResponse.Content.ReadFromJsonAsync<JsonElement>();
-                string? nodeId = label.GetProperty("node_id").GetString();
+                string? nodeId = label.TryGetProperty("node_id", out var refetchNodeIdProp) ? refetchNodeIdProp.GetString() : null;
                 if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
                 return nodeId;
             }
@@ -765,14 +765,14 @@ public class GitHubApi
         }
 
         var label = await response.Content.ReadFromJsonAsync<JsonElement>();
-        string? nodeId = label.GetProperty("node_id").GetString();
+        string? nodeId = label.TryGetProperty("node_id", out var nodeIdProp) ? nodeIdProp.GetString() : null;
         if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
         return nodeId;
     }
 
     /// <summary>
     /// Adds a label to a discussion in a GitHub repository via GraphQL.
-    /// Creates the label in the repository if it does not yet exist.
+    /// The label must already exist in the repository; if not, the method returns a failure message.
     /// </summary>
     public static async Task<string?> AddLabelToDiscussion(
         string githubToken, string org, string repo,
@@ -800,14 +800,8 @@ public class GitHubApi
             string? labelNodeId = await GetLabelNodeId(restClient, org, repo, labelName, action);
             if (labelNodeId is null)
             {
-                action.WriteInfo($"""
-                    [Discussion] Failed to apply label '{labelName}'.
-                        Label does not exist in {org}/{repo}.
-                        {(retry < retries.Length - 1 ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
-                    """);
-                int labelDelay = Math.Min(retries[retry++], MaxLabelDelaySeconds);
-                await Task.Delay(labelDelay * 1000);
-                continue;
+                // Label does not exist and will not appear on its own — fail immediately.
+                return $"Failed to apply label '{labelName}': label does not exist in {org}/{repo}.";
             }
 
             mutation.Variables = new { labelableId = discussionNodeId, labelIds = new[] { labelNodeId } };

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -956,17 +956,17 @@ public class GitHubApi
 
         while (retry < retries.Length)
         {
-            string? labelNodeId = await GetLabelNodeId(restClient, org, repo, labelName, action);
-            if (labelNodeId is null)
-            {
-                // Label does not exist and will not appear on its own — fail immediately.
-                return $"Failed to apply label '{labelName}': label does not exist in {org}/{repo}.";
-            }
-
-            mutation.Variables = new { labelableId = discussionNodeId, labelIds = new[] { labelNodeId } };
-
             try
             {
+                string? labelNodeId = await GetLabelNodeId(restClient, org, repo, labelName, action);
+                if (labelNodeId is null)
+                {
+                    // Label does not exist and will not appear on its own — fail immediately.
+                    return $"Failed to apply label '{labelName}': label does not exist in {org}/{repo}.";
+                }
+
+                mutation.Variables = new { labelableId = discussionNodeId, labelIds = new[] { labelNodeId } };
+
                 var response = await graphqlClient.SendMutationAsync<object>(mutation);
                 if (!(response.Errors?.Any() ?? false)) return null;
 

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -15,6 +15,7 @@ public class GitHubApi
 {
     private static ConcurrentDictionary<string, GraphQLHttpClient> _graphQLClients = new();
     private static ConcurrentDictionary<string, HttpClient> _restClients = new();
+    private static ConcurrentDictionary<string, string> _labelNodeIdCache = new();
     private const int MaxLabelDelaySeconds = 30;
 
     /// <summary>
@@ -668,13 +669,19 @@ public class GitHubApi
 
     private static async Task<string?> GetOrCreateLabelNodeId(HttpClient restClient, string org, string repo, string labelName)
     {
+        string cacheKey = $"{org}/{repo}/{labelName}";
+        if (_labelNodeIdCache.TryGetValue(cacheKey, out string? cached))
+            return cached;
+
         var getResponse = await restClient.GetAsync(
             $"https://api.github.com/repos/{org}/{repo}/labels/{Uri.EscapeDataString(labelName)}");
 
         if (getResponse.IsSuccessStatusCode)
         {
             var label = await getResponse.Content.ReadFromJsonAsync<JsonElement>();
-            return label.GetProperty("node_id").GetString();
+            string? nodeId = label.GetProperty("node_id").GetString();
+            if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
+            return nodeId;
         }
 
         if ((int)getResponse.StatusCode != 404)
@@ -688,7 +695,9 @@ public class GitHubApi
         if (createResponse.IsSuccessStatusCode)
         {
             var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
-            return created.GetProperty("node_id").GetString();
+            string? nodeId = created.GetProperty("node_id").GetString();
+            if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
+            return nodeId;
         }
 
         if ((int)createResponse.StatusCode == 422)
@@ -699,7 +708,9 @@ public class GitHubApi
             if (refetchResponse.IsSuccessStatusCode)
             {
                 var label = await refetchResponse.Content.ReadFromJsonAsync<JsonElement>();
-                return label.GetProperty("node_id").GetString();
+                string? nodeId = label.GetProperty("node_id").GetString();
+                if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
+                return nodeId;
             }
         }
 
@@ -708,6 +719,10 @@ public class GitHubApi
 
     private static async Task<string?> GetLabelNodeId(HttpClient restClient, string org, string repo, string labelName)
     {
+        string cacheKey = $"{org}/{repo}/{labelName}";
+        if (_labelNodeIdCache.TryGetValue(cacheKey, out string? cached))
+            return cached;
+
         var response = await restClient.GetAsync(
             $"https://api.github.com/repos/{org}/{repo}/labels/{Uri.EscapeDataString(labelName)}");
 
@@ -715,7 +730,9 @@ public class GitHubApi
             return null;
 
         var label = await response.Content.ReadFromJsonAsync<JsonElement>();
-        return label.GetProperty("node_id").GetString();
+        string? nodeId = label.GetProperty("node_id").GetString();
+        if (nodeId is not null) _labelNodeIdCache[cacheKey] = nodeId;
+        return nodeId;
     }
 
     /// <summary>

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -18,6 +18,17 @@ public class GitHubApi
     private static ConcurrentDictionary<string, string> _labelNodeIdCache = new();
     private const int MaxLabelDelaySeconds = 30;
 
+    private static int? GetGraphQLNumber(string typeName, string org, string repo, ulong number, ICoreService action)
+    {
+        if (number > int.MaxValue)
+        {
+            action.WriteInfo($"[{typeName} {org}/{repo}#{number}] Failed to retrieve data. GitHub GraphQL item numbers must fit in Int32.");
+            return null;
+        }
+
+        return (int)number;
+    }
+
     /// <summary>
     /// Gets or creates a GraphQL client for the GitHub API using the provided token.
     /// </summary>
@@ -388,6 +399,13 @@ public class GitHubApi
     {
         GraphQLHttpClient client = GetGraphQLClient(githubToken);
         string files = typeof(T) == typeof(PullRequest) ? "files (first: 100) { nodes { path } }" : "";
+        string typeName = typeof(T) == typeof(PullRequest) ? "Pull Request" : "Issue";
+        int? graphQLNumber = GetGraphQLNumber(typeName, org, repo, number, action);
+
+        if (graphQLNumber is null)
+        {
+            return null;
+        }
 
         GraphQLRequest query = new GraphQLRequest
         {
@@ -410,14 +428,13 @@ public class GitHubApi
                 """,
             Variables = new
             {
-                Owner = org,
-                Repo = repo,
-                Number = number
+                owner = org,
+                repo = repo,
+                number = graphQLNumber.Value
             }
         };
 
         byte retry = 0;
-        string typeName = typeof(T) == typeof(PullRequest) ? "Pull Request" : "Issue";
 
         while (retry < retries.Length)
         {
@@ -579,6 +596,12 @@ public class GitHubApi
     public static async Task<Discussion?> GetDiscussion(string githubToken, string org, string repo, ulong number, int[] retries, ICoreService action, bool verbose)
     {
         GraphQLHttpClient client = GetGraphQLClient(githubToken);
+        int? graphQLNumber = GetGraphQLNumber("Discussion", org, repo, number, action);
+
+        if (graphQLNumber is null)
+        {
+            return null;
+        }
 
         GraphQLRequest query = new()
         {
@@ -599,7 +622,7 @@ public class GitHubApi
                     }
                 }
                 """,
-            Variables = new { Owner = org, Repo = repo, Number = number }
+            Variables = new { owner = org, repo = repo, number = graphQLNumber.Value }
         };
 
         byte retry = 0;

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -15,8 +15,6 @@ public class GitHubApi
 {
     private static ConcurrentDictionary<string, GraphQLHttpClient> _graphQLClients = new();
     private static ConcurrentDictionary<string, HttpClient> _restClients = new();
-    // No eviction: this is a short-lived GitHub Actions process. Cache entries are bounded
-    // by the number of distinct labels in the repo (typically < 100) and dropped on exit.
     private static ConcurrentDictionary<string, string> _labelNodeIdCache = new();
     private const int MaxLabelDelaySeconds = 30;
 

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -18,6 +18,11 @@ public class GitHubApi
     private static ConcurrentDictionary<string, string> _labelNodeIdCache = new();
     private const int MaxLabelDelaySeconds = 30;
 
+    private static string GetRetryMessage(byte retry, int[] retries) =>
+        retry + 1 < retries.Length
+            ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..."
+            : $"Retry limit of {retries.Length} reached.";
+
     private static int? GetGraphQLNumber(string typeName, string org, string repo, ulong number, ICoreService action)
     {
         if (number > int.MaxValue)
@@ -253,7 +258,7 @@ public class GitHubApi
             if (after == page.EndCursor)
             {
                 action.WriteError($"Paging did not progress. Cursor: '{after}'. Aborting.");
-                break;
+                throw new ApplicationException($"Paging did not progress for {typeNames} from {org}/{repo}. Cursor '{after}' was returned again.");
             }
 
             pageNumber++;
@@ -374,8 +379,8 @@ public class GitHubApi
 
                         {ex.Message}
 
-                        Total Downloaded: {totalCount}
-                        Applicable for Training: {loadedCount}
+                        Items Downloaded: {loadedCount} (total: {totalCount})
+                        Items to Include: {includedCount} (limit: {(itemLimit.HasValue ? itemLimit : "none")})
                         Page Number: {pageNumber}
                         """);
                 }
@@ -390,7 +395,7 @@ public class GitHubApi
             if (after == page.EndCursor)
             {
                 action.WriteError($"Paging did not progress. Cursor: '{after}'. Aborting.");
-                break;
+                throw new ApplicationException($"Paging did not progress for Discussions from {org}/{repo}. Cursor '{after}' was returned again.");
             }
 
             pageNumber++;
@@ -487,9 +492,9 @@ public class GitHubApi
                 """,
             Variables = new
             {
-                Owner = org,
-                Repo = repo,
-                After = after
+                owner = org,
+                repo = repo,
+                after
             }
         };
 
@@ -554,9 +559,9 @@ public class GitHubApi
                 """,
             Variables = new
             {
-                Owner = org,
-                Repo = repo,
-                After = after
+                owner = org,
+                repo = repo,
+                after
             }
         };
 
@@ -663,7 +668,7 @@ public class GitHubApi
                         action.WriteInfo($"""
                             [{typeName} {org}/{repo}#{number}] Failed to retrieve data.
                                 Rate limit has been reached.
-                                {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                                {GetRetryMessage(retry, retries)}
                             """);
                     }
                     else
@@ -707,7 +712,7 @@ public class GitHubApi
 
                         {ex.Message}
 
-                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                        {GetRetryMessage(retry, retries)}
                     """);
             }
 
@@ -748,7 +753,7 @@ public class GitHubApi
 
             action.WriteInfo($"""
                 [{type} {org}/{repo}#{number}] Failed to add label '{label}'. {response.ReasonPhrase} ({response.StatusCode})
-                    {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    {GetRetryMessage(retry, retries)}
                 """);
 
             int delay = Math.Min(retries[retry++], MaxLabelDelaySeconds);
@@ -788,7 +793,7 @@ public class GitHubApi
 
             action.WriteInfo($"""
                 [{type} {org}/{repo}#{number}] Failed to remove label '{label}'. {response.ReasonPhrase} ({response.StatusCode})
-                    {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    {GetRetryMessage(retry, retries)}
                 """);
 
             int delay = Math.Min(retries[retry++], MaxLabelDelaySeconds);
@@ -851,7 +856,7 @@ public class GitHubApi
                         action.WriteInfo($"""
                             [Discussion {org}/{repo}#{number}] Failed to retrieve data.
                                 Rate limit has been reached.
-                                {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                                {GetRetryMessage(retry, retries)}
                             """);
                     }
                     else
@@ -888,7 +893,7 @@ public class GitHubApi
 
                         {ex.Message}
 
-                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                        {GetRetryMessage(retry, retries)}
                     """);
             }
 
@@ -910,7 +915,11 @@ public class GitHubApi
         if (!response.IsSuccessStatusCode)
         {
             if ((int)response.StatusCode != 404)
+            {
                 action.WriteInfo($"[Label] Unexpected status {(int)response.StatusCode} ({response.ReasonPhrase}) when fetching label '{labelName}' from {org}/{repo}.");
+                throw new HttpRequestException($"Failed to fetch label '{labelName}' from {org}/{repo}. Status {(int)response.StatusCode} ({response.ReasonPhrase}).");
+            }
+
             return null;
         }
 
@@ -964,7 +973,7 @@ public class GitHubApi
                 action.WriteInfo($"""
                     [Discussion] Failed to apply label '{labelName}'.
                         {string.Join("; ", response.Errors!.Select(e => e.Message))}
-                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                        {GetRetryMessage(retry, retries)}
                     """);
             }
             catch (Exception ex) when (
@@ -976,7 +985,7 @@ public class GitHubApi
                 action.WriteInfo($"""
                     [Discussion] Failed to apply label '{labelName}'.
                         {ex.Message}
-                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                        {GetRetryMessage(retry, retries)}
                     """);
             }
 
@@ -998,10 +1007,6 @@ public class GitHubApi
         var restClient = GetRestClient(githubToken);
         var graphqlClient = GetGraphQLClient(githubToken);
 
-        // If the label doesn't exist there's nothing to remove
-        string? labelNodeId = await GetLabelNodeId(restClient, org, repo, labelName, action);
-        if (labelNodeId is null) return null;
-
         var mutation = new GraphQLRequest
         {
             Query = """
@@ -1010,8 +1015,7 @@ public class GitHubApi
                         clientMutationId
                     }
                 }
-                """,
-            Variables = new { labelableId = discussionNodeId, labelIds = new[] { labelNodeId } }
+                """
         };
 
         byte retry = 0;
@@ -1020,13 +1024,19 @@ public class GitHubApi
         {
             try
             {
+                // If the label doesn't exist there's nothing to remove.
+                string? labelNodeId = await GetLabelNodeId(restClient, org, repo, labelName, action);
+                if (labelNodeId is null) return null;
+
+                mutation.Variables = new { labelableId = discussionNodeId, labelIds = new[] { labelNodeId } };
+
                 var response = await graphqlClient.SendMutationAsync<object>(mutation);
                 if (!(response.Errors?.Any() ?? false)) return null;
 
                 action.WriteInfo($"""
                     [Discussion] Failed to remove label '{labelName}'.
                         {string.Join("; ", response.Errors!.Select(e => e.Message))}
-                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                        {GetRetryMessage(retry, retries)}
                     """);
             }
             catch (Exception ex) when (
@@ -1038,7 +1048,7 @@ public class GitHubApi
                 action.WriteInfo($"""
                     [Discussion] Failed to remove label '{labelName}'.
                         {ex.Message}
-                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                        {GetRetryMessage(retry, retries)}
                     """);
             }
 

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -234,8 +234,8 @@ public class GitHubApi
 
                         {ex.Message}
 
-                        Total Downloaded: {totalCount}
-                        Applicable for Training: {loadedCount}
+                        Items Downloaded: {loadedCount} (total: {totalCount})
+                        Items to Include: {includedCount} (limit: {(itemLimit.HasValue ? itemLimit : "none")})
                         Page Number: {pageNumber}
                         """
                     );

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -15,6 +15,8 @@ public class GitHubApi
 {
     private static ConcurrentDictionary<string, GraphQLHttpClient> _graphQLClients = new();
     private static ConcurrentDictionary<string, HttpClient> _restClients = new();
+    // No eviction: this is a short-lived GitHub Actions process. Cache entries are bounded
+    // by the number of distinct labels in the repo (typically < 100) and dropped on exit.
     private static ConcurrentDictionary<string, string> _labelNodeIdCache = new();
     private const int MaxLabelDelaySeconds = 30;
 

--- a/IssueLabeler/src/GitHubClient/QueryModel.cs
+++ b/IssueLabeler/src/GitHubClient/QueryModel.cs
@@ -22,7 +22,7 @@ public class Issue
 {
     public required ulong Number { get; init; }
     public required string Title { get; init; }
-    public required Author Author { get; init; }
+    public Author? Author { get; init; }
     public required string Body { get; init; }
     public required Page<Label> Labels { get; init; }
 
@@ -92,7 +92,7 @@ public class Discussion
     public required ulong Number { get; init; }
     public required string Id { get; init; }
     public required string Title { get; init; }
-    public required Author Author { get; init; }
+    public Author? Author { get; init; }
     public required string Body { get; init; }
     public required Page<Label> Labels { get; init; }
 

--- a/IssueLabeler/src/GitHubClient/QueryModel.cs
+++ b/IssueLabeler/src/GitHubClient/QueryModel.cs
@@ -86,3 +86,15 @@ public class PageInfo
     public required bool HasNextPage { get; init; }
     public string? EndCursor { get; init; }
 }
+
+public class Discussion
+{
+    public required ulong Number { get; init; }
+    public required string Id { get; init; }
+    public required string Title { get; init; }
+    public required Author Author { get; init; }
+    public required string Body { get; init; }
+    public required Page<Label> Labels { get; init; }
+
+    public string[] LabelNames => this.Labels.Nodes.Select(label => label.Name).ToArray();
+}

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -60,7 +60,9 @@ public struct Args
               EXCLUDED_AUTHORS        Comma-separated list of authors to exclude.
               RETRIES                 Comma-separated retry delays in seconds.
                                       Defaults to: 30,30,300,300,3000,3000.
-              TEST                    Run in test mode, outputting predictions without applying labels.
+              DRY_RUN                 Run in dry-run mode, outputting predictions without applying labels.
+                                      Must be one of: true, false, TRUE, FALSE
+              TEST                    Deprecated alias for DRY_RUN.
                                       Must be one of: true, false, TRUE, FALSE
               VERBOSE                 Enable verbose output.
                                       Must be one of: true, false, TRUE, FALSE
@@ -83,6 +85,7 @@ public struct Args
         argUtils.TryGetIntArray("retries", out var retries);
         argUtils.TryGetString("default_label", out var defaultLabel);
         argUtils.TryGetNumberRanges("discussions", out var discussions);
+        argUtils.TryGetFlag("dry_run", out var dryRun);
         argUtils.TryGetFlag("test", out var test);
         argUtils.TryGetFlag("verbose", out var verbose);
 
@@ -113,7 +116,7 @@ public struct Args
             ExcludedAuthors = excludedAuthors,
             Threshold = threshold ?? 0.4f,
             Retries = retries ?? [30, 30, 300, 300, 3000, 3000],
-            Test = test ?? false,
+            Test = dryRun ?? test ?? false,
             Verbose = verbose ?? false
         };
 

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -68,8 +68,6 @@ public struct Args
                                       Defaults to: 30,30,300,300,3000,3000.
               DRY_RUN                 Run in dry-run mode, outputting predictions without applying labels.
                                       Must be one of: true, false, TRUE, FALSE
-              TEST                    Deprecated alias for DRY_RUN.
-                                      Must be one of: true, false, TRUE, FALSE
               VERBOSE                 Enable verbose output.
                                       Must be one of: true, false, TRUE, FALSE
             """);

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -22,7 +22,7 @@ public struct Args
     public byte MaxLabels { get; set; }
     public int[] Retries { get; set; }
     public bool Verbose { get; set; }
-    public bool Test { get; set; }
+    public bool DryRun { get; set; }
 
     static void ShowUsage(string? message, ICoreService action)
     {
@@ -114,7 +114,6 @@ public struct Args
             }
         }
 
-        argUtils.TryGetFlag("test", out var test);
         argUtils.TryGetFlag("verbose", out var verbose);
 
         if (org is null || repo is null || threshold is null || labelPredicate is null ||
@@ -145,7 +144,7 @@ public struct Args
             ExcludedAuthors = excludedAuthors,
             Threshold = threshold ?? 0.4f,
             Retries = retries ?? [30, 30, 300, 300, 3000, 3000],
-            Test = dryRun ?? test ?? false,
+            DryRun = dryRun ?? false,
             Verbose = verbose ?? false
         };
 

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -5,8 +5,6 @@ using Actions.Core.Services;
 
 public struct Args
 {
-    private const int MaxLabelsLimit = 5;
-
     public string GitHubToken => Environment.GetEnvironmentVariable("GITHUB_TOKEN")!;
     public string Org { get; set; }
     public string Repo { get; set; }
@@ -18,7 +16,6 @@ public struct Args
     public string? PullsModelPath { get; set; }
     public List<ulong>? Pulls { get; set; }
     public string? DefaultLabel { get; set; }
-    public int MaxLabels { get; set; }
     public List<ulong>? Discussions { get; set; }
     public int[] Retries { get; set; }
     public bool Verbose { get; set; }
@@ -60,9 +57,6 @@ public struct Args
               THRESHOLD               Minimum prediction confidence threshold. Range (0,1].
                                       Defaults to: 0.4.
               DEFAULT_LABEL           Label to apply if no label is predicted.
-              MAX_LABELS              Maximum number of labels to apply when multiple predictions
-                                      meet the threshold. Must be a positive integer in [1, 5].
-                                      Defaults to: 1.
               EXCLUDED_AUTHORS        Comma-separated list of authors to exclude.
               RETRIES                 Comma-separated retry delays in seconds.
                                       Defaults to: 30,30,300,300,3000,3000.
@@ -88,17 +82,6 @@ public struct Args
         argUtils.TryGetFloat("threshold", out var threshold);
         argUtils.TryGetIntArray("retries", out var retries);
         argUtils.TryGetString("default_label", out var defaultLabel);
-        argUtils.TryGetString("max_labels", out var maxLabelsStr);
-        int? maxLabels = null;
-        if (maxLabelsStr is not null)
-        {
-            if (!int.TryParse(maxLabelsStr, out int parsedMaxLabels) || parsedMaxLabels < 1 || parsedMaxLabels > MaxLabelsLimit)
-            {
-                ShowUsage($"Input 'max_labels' must be a positive integer between 1 and {MaxLabelsLimit}.", action);
-                return null;
-            }
-            maxLabels = parsedMaxLabels;
-        }
         argUtils.TryGetNumberRanges("discussions", out var discussions);
         argUtils.TryGetFlag("test", out var test);
         argUtils.TryGetFlag("verbose", out var verbose);
@@ -122,7 +105,6 @@ public struct Args
             Repo = repo,
             LabelPredicate = labelPredicate,
             DefaultLabel = defaultLabel,
-            MaxLabels = maxLabels ?? 1,
             IssuesModelPath = issuesModelPath,
             Issues = issues,
             PullsModelPath = pullsModelPath,

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -103,6 +103,12 @@ public struct Args
             return null;
         }
 
+        if (maxLabels is <= 0)
+        {
+            ShowUsage("Input 'max_labels' must be a positive integer when provided.", action);
+            return null;
+        }
+
         Args argsData = new()
         {
             Org = org,
@@ -116,7 +122,7 @@ public struct Args
             Discussions = discussions,
             ExcludedAuthors = excludedAuthors,
             Threshold = threshold ?? 0.4f,
-            MaxLabels = maxLabels is > 0 ? maxLabels.Value : 1,
+            MaxLabels = maxLabels ?? 1,
             Retries = retries ?? [30, 30, 300, 300, 3000, 3000],
             Test = test ?? false,
             Verbose = verbose ?? false

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -5,6 +5,8 @@ using Actions.Core.Services;
 
 public struct Args
 {
+    private const int MaxLabelsLimit = 5;
+
     public string GitHubToken => Environment.GetEnvironmentVariable("GITHUB_TOKEN")!;
     public string Org { get; set; }
     public string Repo { get; set; }
@@ -16,6 +18,8 @@ public struct Args
     public string? PullsModelPath { get; set; }
     public List<ulong>? Pulls { get; set; }
     public string? DefaultLabel { get; set; }
+    public int MaxLabels { get; set; }
+    public List<ulong>? Discussions { get; set; }
     public int[] Retries { get; set; }
     public bool Verbose { get; set; }
     public bool Test { get; set; }
@@ -46,10 +50,19 @@ public struct Args
               PULLS                   Comma-separated list of pull request number ranges.
                                       Example: 1-3,7,5-9.
 
+            Required inputs for predicting discussion labels:
+              ISSUES_MODEL            Path to the issues model file (ZIP file).
+                                      Discussions use the issues model for prediction.
+              DISCUSSIONS             Comma-separated list of discussion number ranges.
+                                      Example: 1-3,7,5-9.
+
             Optional inputs:
               THRESHOLD               Minimum prediction confidence threshold. Range (0,1].
                                       Defaults to: 0.4.
               DEFAULT_LABEL           Label to apply if no label is predicted.
+              MAX_LABELS              Maximum number of labels to apply when multiple predictions
+                                      meet the threshold. Must be a positive integer in [1, 5].
+                                      Defaults to: 1.
               EXCLUDED_AUTHORS        Comma-separated list of authors to exclude.
               RETRIES                 Comma-separated retry delays in seconds.
                                       Defaults to: 30,30,300,300,3000,3000.
@@ -75,13 +88,31 @@ public struct Args
         argUtils.TryGetFloat("threshold", out var threshold);
         argUtils.TryGetIntArray("retries", out var retries);
         argUtils.TryGetString("default_label", out var defaultLabel);
+        argUtils.TryGetString("max_labels", out var maxLabelsStr);
+        int? maxLabels = null;
+        if (maxLabelsStr is not null)
+        {
+            if (!int.TryParse(maxLabelsStr, out int parsedMaxLabels) || parsedMaxLabels < 1 || parsedMaxLabels > MaxLabelsLimit)
+            {
+                ShowUsage($"Input 'max_labels' must be a positive integer between 1 and {MaxLabelsLimit}.", action);
+                return null;
+            }
+            maxLabels = parsedMaxLabels;
+        }
+        argUtils.TryGetNumberRanges("discussions", out var discussions);
         argUtils.TryGetFlag("test", out var test);
         argUtils.TryGetFlag("verbose", out var verbose);
 
         if (org is null || repo is null || threshold is null || labelPredicate is null ||
-            (issues is null && pulls is null))
+            (issues is null && pulls is null && discussions is null))
         {
             ShowUsage(null, action);
+            return null;
+        }
+
+        if (discussions is not null && issuesModelPath is null)
+        {
+            ShowUsage("Input 'issues_model' is required when 'discussions' is provided (discussions use the issues model for prediction).", action);
             return null;
         }
 
@@ -91,10 +122,12 @@ public struct Args
             Repo = repo,
             LabelPredicate = labelPredicate,
             DefaultLabel = defaultLabel,
+            MaxLabels = maxLabels ?? 1,
             IssuesModelPath = issuesModelPath,
             Issues = issues,
             PullsModelPath = pullsModelPath,
             Pulls = pulls,
+            Discussions = discussions,
             ExcludedAuthors = excludedAuthors,
             Threshold = threshold ?? 0.4f,
             Retries = retries ?? [30, 30, 300, 300, 3000, 3000],

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -9,6 +9,7 @@ public struct Args
     public string Org { get; set; }
     public string Repo { get; set; }
     public float Threshold { get; set; }
+    public int MaxLabels { get; set; }
     public Func<string, bool> LabelPredicate { get; set; }
     public string[]? ExcludedAuthors { get; set; }
     public string? IssuesModelPath { get; set; }
@@ -56,6 +57,8 @@ public struct Args
             Optional inputs:
               THRESHOLD               Minimum prediction confidence threshold. Range (0,1].
                                       Defaults to: 0.4.
+                            MAX_LABELS              Maximum number of labels to apply when predictions meet the threshold.
+                                                                            Must be a positive integer. Defaults to: 1.
               DEFAULT_LABEL           Label to apply if no label is predicted.
               EXCLUDED_AUTHORS        Comma-separated list of authors to exclude.
               RETRIES                 Comma-separated retry delays in seconds.
@@ -80,6 +83,7 @@ public struct Args
         argUtils.TryGetNumberRanges("pulls", out var pulls);
         argUtils.TryGetStringArray("excluded_authors", out var excludedAuthors);
         argUtils.TryGetFloat("threshold", out var threshold);
+        argUtils.TryGetInt("max_labels", out var maxLabels);
         argUtils.TryGetIntArray("retries", out var retries);
         argUtils.TryGetString("default_label", out var defaultLabel);
         argUtils.TryGetNumberRanges("discussions", out var discussions);
@@ -112,6 +116,7 @@ public struct Args
             Discussions = discussions,
             ExcludedAuthors = excludedAuthors,
             Threshold = threshold ?? 0.4f,
+            MaxLabels = maxLabels is > 0 ? maxLabels.Value : 1,
             Retries = retries ?? [30, 30, 300, 300, 3000, 3000],
             Test = test ?? false,
             Verbose = verbose ?? false

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -9,7 +9,6 @@ public struct Args
     public string Org { get; set; }
     public string Repo { get; set; }
     public float Threshold { get; set; }
-    public int MaxLabels { get; set; }
     public Func<string, bool> LabelPredicate { get; set; }
     public string[]? ExcludedAuthors { get; set; }
     public string? IssuesModelPath { get; set; }
@@ -57,8 +56,6 @@ public struct Args
             Optional inputs:
               THRESHOLD               Minimum prediction confidence threshold. Range (0,1].
                                       Defaults to: 0.4.
-                            MAX_LABELS              Maximum number of labels to apply when predictions meet the threshold.
-                                                                            Must be a positive integer. Defaults to: 1.
               DEFAULT_LABEL           Label to apply if no label is predicted.
               EXCLUDED_AUTHORS        Comma-separated list of authors to exclude.
               RETRIES                 Comma-separated retry delays in seconds.
@@ -83,7 +80,6 @@ public struct Args
         argUtils.TryGetNumberRanges("pulls", out var pulls);
         argUtils.TryGetStringArray("excluded_authors", out var excludedAuthors);
         argUtils.TryGetFloat("threshold", out var threshold);
-        argUtils.TryGetInt("max_labels", out var maxLabels);
         argUtils.TryGetIntArray("retries", out var retries);
         argUtils.TryGetString("default_label", out var defaultLabel);
         argUtils.TryGetNumberRanges("discussions", out var discussions);
@@ -103,12 +99,6 @@ public struct Args
             return null;
         }
 
-        if (maxLabels is <= 0)
-        {
-            ShowUsage("Input 'max_labels' must be a positive integer when provided.", action);
-            return null;
-        }
-
         Args argsData = new()
         {
             Org = org,
@@ -122,7 +112,6 @@ public struct Args
             Discussions = discussions,
             ExcludedAuthors = excludedAuthors,
             Threshold = threshold ?? 0.4f,
-            MaxLabels = maxLabels ?? 1,
             Retries = retries ?? [30, 30, 300, 300, 3000, 3000],
             Test = test ?? false,
             Verbose = verbose ?? false

--- a/IssueLabeler/src/Predictor/Models.cs
+++ b/IssueLabeler/src/Predictor/Models.cs
@@ -24,6 +24,14 @@ public class Issue
         Labels = issue.LabelNames;
         HasMoreLabels = issue.Labels.HasNextPage;
     }
+
+    public Issue(GitHubClient.Discussion discussion)
+    {
+        Title = discussion.Title;
+        Body = discussion.Body;
+        Labels = discussion.LabelNames;
+        HasMoreLabels = discussion.Labels.HasNextPage;
+    }
 }
 
 public class PullRequest : Issue

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -41,6 +41,9 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
             continue;
         }
 
+        // CreatePredictionEngine is called once per task. ITransformer is shared and thread-safe;
+        // PredictionEngine itself is not, but each Task.Run closure captures its own instance.
+        // Microsoft.Extensions.ML (PredictionEnginePool) is not a dependency of this project.
         tasks.Add(Task.Run(() => ProcessPrediction(
             issueContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel),
             issueNumber,
@@ -80,6 +83,7 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
             continue;
         }
 
+        // See issues block above: one PredictionEngine per Task.Run, ITransformer shared.
         tasks.Add(Task.Run(() => ProcessPrediction(
             pullContext.Model.CreatePredictionEngine<PullRequest, LabelPrediction>(pullModel),
             pullNumber,
@@ -119,6 +123,7 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
             continue;
         }
 
+        // See issues block above: one PredictionEngine per Task.Run, ITransformer shared.
         tasks.Add(Task.Run(() => ProcessPrediction(
             discussionContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(discussionModel),
             result.Number,

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -47,19 +47,16 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
             continue;
         }
 
-        tasks.Add(Task.Run(() =>
-        {
-            return ProcessPrediction(
-                issuePredictors!.Value!,
-                issueNumber,
-                new Issue(result),
-                argsData.LabelPredicate,
-                argsData.DefaultLabel,
-                ModelType.Issue,
-                argsData.Retries,
-                argsData.Test
-            );
-        }));
+        tasks.Add(Task.Run(() => ProcessPrediction(
+            issuePredictors!.Value!,
+            issueNumber,
+            new Issue(result),
+            argsData.LabelPredicate,
+            argsData.DefaultLabel,
+            ModelType.Issue,
+            argsData.Retries,
+            argsData.Test
+        )));
 
         action.WriteInfo($"[Issue {argsData.Org}/{argsData.Repo}#{issueNumber}] Queued for prediction.");
     }
@@ -89,19 +86,16 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
             continue;
         }
 
-        tasks.Add(Task.Run(() =>
-        {
-            return ProcessPrediction(
-                pullPredictors!.Value!,
-                pullNumber,
-                new PullRequest(result),
-                argsData.LabelPredicate,
-                argsData.DefaultLabel,
-                ModelType.PullRequest,
-                argsData.Retries,
-                argsData.Test
-            );
-        }));
+        tasks.Add(Task.Run(() => ProcessPrediction(
+            pullPredictors!.Value!,
+            pullNumber,
+            new PullRequest(result),
+            argsData.LabelPredicate,
+            argsData.DefaultLabel,
+            ModelType.PullRequest,
+            argsData.Retries,
+            argsData.Test
+        )));
 
         action.WriteInfo($"[Pull Request {argsData.Org}/{argsData.Repo}#{pullNumber}] Queued for prediction.");
     }
@@ -134,20 +128,17 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
             continue;
         }
 
-        tasks.Add(Task.Run(() =>
-        {
-            return ProcessPrediction(
-                issuePredictors!.Value!,
-                result.Number,
-                new Issue(result),
-                argsData.LabelPredicate,
-                argsData.DefaultLabel,
-                ModelType.Discussion,
-                argsData.Retries,
-                argsData.Test,
-                nodeId: result.Id
-            );
-        }));
+        tasks.Add(Task.Run(() => ProcessPrediction(
+            issuePredictors!.Value!,
+            result.Number,
+            new Issue(result),
+            argsData.LabelPredicate,
+            argsData.DefaultLabel,
+            ModelType.Discussion,
+            argsData.Retries,
+            argsData.Test,
+            nodeId: result.Id
+        )));
 
         action.WriteInfo($"[Discussion {argsData.Org}/{argsData.Repo}#{discussionNumber}] Queued for prediction.");
     }

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -23,7 +23,6 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
     await action.WriteStatusAsync($"Loading prediction engine for issues model...");
     var issueContext = new MLContext();
     var issueModel = issueContext.Model.Load(argsData.IssuesModelPath, out _);
-    var issuePredictor = issueContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel);
     await action.WriteStatusAsync($"Issues prediction engine ready.");
 
     foreach (ulong issueNumber in argsData.Issues)
@@ -43,7 +42,7 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
         }
 
         tasks.Add(Task.Run(() => ProcessPrediction(
-            issuePredictor,
+            issueContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel),
             issueNumber,
             new Issue(result),
             argsData.LabelPredicate,
@@ -62,7 +61,6 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
     await action.WriteStatusAsync($"Loading prediction engine for pulls model...");
     var pullContext = new MLContext();
     var pullModel = pullContext.Model.Load(argsData.PullsModelPath, out _);
-    var pullPredictor = pullContext.Model.CreatePredictionEngine<PullRequest, LabelPrediction>(pullModel);
     await action.WriteStatusAsync($"Pulls prediction engine ready.");
 
     foreach (ulong pullNumber in argsData.Pulls)
@@ -82,7 +80,7 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
         }
 
         tasks.Add(Task.Run(() => ProcessPrediction(
-            pullPredictor,
+            pullContext.Model.CreatePredictionEngine<PullRequest, LabelPrediction>(pullModel),
             pullNumber,
             new PullRequest(result),
             argsData.LabelPredicate,
@@ -101,7 +99,6 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
     await action.WriteStatusAsync($"Loading prediction engine for discussions (uses issues model)...");
     var discussionContext = new MLContext();
     var discussionModel = discussionContext.Model.Load(argsData.IssuesModelPath, out _);
-    var discussionPredictor = discussionContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(discussionModel);
     await action.WriteStatusAsync($"Discussions prediction engine ready.");
 
     foreach (ulong discussionNumber in argsData.Discussions)
@@ -121,7 +118,7 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
         }
 
         tasks.Add(Task.Run(() => ProcessPrediction(
-            discussionPredictor,
+            discussionContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(discussionModel),
             result.Number,
             new Issue(result),
             argsData.LabelPredicate,

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -20,12 +20,15 @@ List<Task<(ulong Number, string ResultMessage, bool Success)>> tasks = new();
 
 MLContext? issueContext = null;
 ITransformer? issueModel = null;
+ThreadLocal<PredictionEngine<Issue, LabelPrediction>>? issuePredictors = null;
+ThreadLocal<PredictionEngine<PullRequest, LabelPrediction>>? pullPredictors = null;
 
 if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
 {
     await action.WriteStatusAsync($"Loading prediction engine for issues model...");
     issueContext = new MLContext();
     issueModel = issueContext.Model.Load(argsData.IssuesModelPath, out _);
+    issuePredictors = new(() => issueContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel));
     await action.WriteStatusAsync($"Issues prediction engine ready.");
 
     foreach (ulong issueNumber in argsData.Issues)
@@ -46,9 +49,8 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
 
         tasks.Add(Task.Run(() =>
         {
-            var predictor = issueContext!.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel!);
             return ProcessPrediction(
-                predictor,
+                issuePredictors!.Value!,
                 issueNumber,
                 new Issue(result),
                 argsData.LabelPredicate,
@@ -68,6 +70,7 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
     await action.WriteStatusAsync($"Loading prediction engine for pulls model...");
     var pullContext = new MLContext();
     var pullModel = pullContext.Model.Load(argsData.PullsModelPath, out _);
+    pullPredictors = new(() => pullContext.Model.CreatePredictionEngine<PullRequest, LabelPrediction>(pullModel));
     await action.WriteStatusAsync($"Pulls prediction engine ready.");
 
     foreach (ulong pullNumber in argsData.Pulls)
@@ -88,9 +91,8 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
 
         tasks.Add(Task.Run(() =>
         {
-            var predictor = pullContext.Model.CreatePredictionEngine<PullRequest, LabelPrediction>(pullModel);
             return ProcessPrediction(
-                predictor,
+                pullPredictors!.Value!,
                 pullNumber,
                 new PullRequest(result),
                 argsData.LabelPredicate,
@@ -112,12 +114,13 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
         await action.WriteStatusAsync($"Loading prediction engine for discussions (uses issues model)...");
         issueContext = new MLContext();
         issueModel = issueContext.Model.Load(argsData.IssuesModelPath, out _);
+        issuePredictors = new(() => issueContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel));
         await action.WriteStatusAsync($"Discussions prediction engine ready.");
     }
 
     foreach (ulong discussionNumber in argsData.Discussions)
     {
-        var result = await GitHubApi.GetDiscussion(argsData.GitHubToken, argsData.Org, argsData.Repo, discussionNumber, argsData.Retries, action, argsData.Verbose);
+        var result = await GitHubApi.GetDiscussion(argsData.GitHubToken, argsData.Org, argsData.Repo, discussionNumber, argsData.Retries, action);
 
         if (result is null)
         {
@@ -133,9 +136,8 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
 
         tasks.Add(Task.Run(() =>
         {
-            var predictor = issueContext!.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel!);
             return ProcessPrediction(
-                predictor,
+                issuePredictors!.Value!,
                 result.Number,
                 new Issue(result),
                 argsData.LabelPredicate,
@@ -157,6 +159,9 @@ foreach (var prediction in predictionResults.OrderBy(p => p.Number))
 {
     action.WriteInfo(prediction.ResultMessage);
 }
+
+issuePredictors?.Dispose();
+pullPredictors?.Dispose();
 
 await action.Summary.WritePersistentAsync();
 return success ? 0 : 1;

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -44,16 +44,20 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
             continue;
         }
 
-        tasks.Add(Task.Run(() => ProcessPrediction(
-            issueContext!.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel!),
-            issueNumber,
-            new Issue(result),
-            argsData.LabelPredicate,
-            argsData.DefaultLabel,
-            ModelType.Issue,
-            argsData.Retries,
-            argsData.Test
-        )));
+        tasks.Add(Task.Run(() =>
+        {
+            var predictor = issueContext!.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel!);
+            return ProcessPrediction(
+                predictor,
+                issueNumber,
+                new Issue(result),
+                argsData.LabelPredicate,
+                argsData.DefaultLabel,
+                ModelType.Issue,
+                argsData.Retries,
+                argsData.Test
+            );
+        }));
 
         action.WriteInfo($"[Issue {argsData.Org}/{argsData.Repo}#{issueNumber}] Queued for prediction.");
     }
@@ -82,16 +86,20 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
             continue;
         }
 
-        tasks.Add(Task.Run(() => ProcessPrediction(
-            pullContext.Model.CreatePredictionEngine<PullRequest, LabelPrediction>(pullModel),
-            pullNumber,
-            new PullRequest(result),
-            argsData.LabelPredicate,
-            argsData.DefaultLabel,
-            ModelType.PullRequest,
-            argsData.Retries,
-            argsData.Test
-        )));
+        tasks.Add(Task.Run(() =>
+        {
+            var predictor = pullContext.Model.CreatePredictionEngine<PullRequest, LabelPrediction>(pullModel);
+            return ProcessPrediction(
+                predictor,
+                pullNumber,
+                new PullRequest(result),
+                argsData.LabelPredicate,
+                argsData.DefaultLabel,
+                ModelType.PullRequest,
+                argsData.Retries,
+                argsData.Test
+            );
+        }));
 
         action.WriteInfo($"[Pull Request {argsData.Org}/{argsData.Repo}#{pullNumber}] Queued for prediction.");
     }
@@ -123,17 +131,21 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
             continue;
         }
 
-        tasks.Add(Task.Run(() => ProcessPrediction(
-            issueContext!.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel!),
-            result.Number,
-            new Issue(result),
-            argsData.LabelPredicate,
-            argsData.DefaultLabel,
-            ModelType.Discussion,
-            argsData.Retries,
-            argsData.Test,
-            nodeId: result.Id
-        )));
+        tasks.Add(Task.Run(() =>
+        {
+            var predictor = issueContext!.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel!);
+            return ProcessPrediction(
+                predictor,
+                result.Number,
+                new Issue(result),
+                argsData.LabelPredicate,
+                argsData.DefaultLabel,
+                ModelType.Discussion,
+                argsData.Retries,
+                argsData.Test,
+                nodeId: result.Id
+            );
+        }));
 
         action.WriteInfo($"[Discussion {argsData.Org}/{argsData.Repo}#{discussionNumber}] Queued for prediction.");
     }
@@ -185,7 +197,17 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
     (ulong, string, bool) Success() => GetResult(true);
     (ulong, string, bool) Failure() => GetResult(false);
 
+    string ApplyVerb() => test ? "would be applied" : "applied";
+    string RemoveVerb() => test ? "would be removed" : "removed";
+
     predictionResults.Add(summary => summary.AddRawMarkdown($"- **{argsData.Org}/{argsData.Repo}#{number}**", true));
+
+    if (type == ModelType.Discussion && nodeId is null)
+    {
+        predictionResults.Add(summary => summary.AddRawMarkdown("    - **Error**: discussion node ID is missing, so labels cannot be applied via GraphQL.", true));
+        resultMessageParts.Add("Error occurred preparing discussion label mutation.");
+        return Failure();
+    }
 
     if (issueOrPull.HasMoreLabels)
     {
@@ -214,8 +236,8 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
 
             if (error is null)
             {
-                predictionResults.Add(summary => summary.AddRawMarkdown($"    - Removed default label `{defaultLabel}`.", true));
-                resultMessageParts.Add($"Default label '{defaultLabel}' removed.");
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - Default label `{defaultLabel}` {RemoveVerb()}.", true));
+                resultMessageParts.Add($"Default label '{defaultLabel}' {RemoveVerb()}.");
                 return Success();
             }
             else
@@ -288,8 +310,8 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
 
             if (error is null)
             {
-                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **`{labelToApply.Label}` applied**", true));
-                resultMessageParts.Add($"Label '{labelToApply.Label}' applied.");
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **`{labelToApply.Label}` {ApplyVerb()}**", true));
+                resultMessageParts.Add($"Label '{labelToApply.Label}' {ApplyVerb()}.");
             }
             else
             {
@@ -308,8 +330,8 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
 
             if (error is null)
             {
-                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Removed default label `{defaultLabel}`**", true));
-                resultMessageParts.Add($"Default label '{defaultLabel}' removed.");
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Default label `{defaultLabel}` {RemoveVerb()}**", true));
+                resultMessageParts.Add($"Default label '{defaultLabel}' {RemoveVerb()}.");
                 return Success();
             }
             else
@@ -340,8 +362,8 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
 
             if (error is null)
             {
-                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Default label `{defaultLabel}` applied.**", true));
-                resultMessageParts.Add($"No prediction made. Default label '{defaultLabel}' applied.");
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Default label `{defaultLabel}` {ApplyVerb()}.**", true));
+                resultMessageParts.Add($"No prediction made. Default label '{defaultLabel}' {ApplyVerb()}.");
                 return Success();
             }
             else

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -271,6 +271,11 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         predictionResults.Add(summary => summary.AddRawMarkdown($"        - `{labelPrediction.Label}` - Score: {labelPrediction.Score}", true));
     }
 
+    if (argsData.Verbose && predictions.Count > 0)
+    {
+        resultMessageParts.Add($"Top predictions: {string.Join(", ", predictions.Select(p => $"'{p.Label}'={p.Score:0.000}"))}. Threshold={argsData.Threshold:0.000}; max_labels={argsData.MaxLabels}.");
+    }
+
     if (topLabels.Count > 0)
     {
         foreach (var labelToApply in topLabels)

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -47,6 +47,7 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
             new Issue(result),
             argsData.LabelPredicate,
             argsData.DefaultLabel,
+            argsData.MaxLabels,
             ModelType.Issue,
             argsData.Retries,
             argsData.Test
@@ -85,6 +86,7 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
             new PullRequest(result),
             argsData.LabelPredicate,
             argsData.DefaultLabel,
+            argsData.MaxLabels,
             ModelType.PullRequest,
             argsData.Retries,
             argsData.Test
@@ -123,6 +125,7 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
             new Issue(result),
             argsData.LabelPredicate,
             argsData.DefaultLabel,
+            argsData.MaxLabels,
             ModelType.Discussion,
             argsData.Retries,
             argsData.Test,
@@ -143,7 +146,7 @@ foreach (var prediction in predictionResults.OrderBy(p => p.Number))
 await action.Summary.WritePersistentAsync();
 return success ? 0 : 1;
 
-async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, ulong number, T issueOrPull, Func<string, bool> labelPredicate, string? defaultLabel, ModelType type, int[] retries, bool test, string? nodeId = null) where T : Issue
+async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, ulong number, T issueOrPull, Func<string, bool> labelPredicate, string? defaultLabel, int maxLabels, ModelType type, int[] retries, bool test, string? nodeId = null) where T : Issue
 {
     List<Action<Summary>> predictionResults = [];
     string typeName = type switch
@@ -244,15 +247,16 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         })
         // Ensure predicted labels match the expected predicate
         .Where(prediction => labelPredicate(prediction.Label))
-        // Capture the top 3 for including in the output
+        // Capture the top max(3, maxLabels) for including in the output
         .OrderByDescending(p => p.Score)
-        .Take(3);
+        .Take(Math.Max(3, maxLabels))
+        .ToList();
 
-    var bestScore = predictions.FirstOrDefault(p => p.Score >= argsData.Threshold);
+    var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(maxLabels).ToList();
 
-    if (bestScore is not null)
+    if (topLabels.Count > 0)
     {
-        predictionResults.Add(summary => summary.AddRawMarkdown($"    - Predicted label: `{bestScore.Label}` meets the threshold of {argsData.Threshold}.", true));
+        predictionResults.Add(summary => summary.AddRawMarkdown($"    - {topLabels.Count} label prediction(s) meet the threshold of {argsData.Threshold}.", true));
     }
     else
     {
@@ -264,49 +268,51 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         predictionResults.Add(summary => summary.AddRawMarkdown($"        - `{labelPrediction.Label}` - Score: {labelPrediction.Score}", true));
     }
 
-    if (bestScore is not null)
+    if (topLabels.Count > 0)
     {
-        if (!test)
+        foreach (var labelToApply in topLabels)
         {
-            error = await ApplyLabel(bestScore.Label);
-        }
-
-        if (error is null)
-        {
-            predictionResults.Add(summary => summary.AddRawMarkdown($"    - **`{bestScore.Label}` applied**", true));
-            resultMessageParts.Add($"Label '{bestScore.Label}' applied.");
-
-            if (hasDefaultLabel && defaultLabel is not null)
+            error = null;
+            if (!test)
             {
-                if (!test)
-                {
-                    error = await UnapplyLabel(defaultLabel);
-                }
+                error = await ApplyLabel(labelToApply.Label);
+            }
 
-                if (error is null)
-                {
-                    predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Removed default label `{defaultLabel}`**", true));
-                    resultMessageParts.Add($"Default label '{defaultLabel}' removed.");
-                    return Success();
-                }
-                else
-                {
-                    predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error removing default label `{defaultLabel}`**: {error}", true));
-                    resultMessageParts.Add($"Error occurred removing default label '{defaultLabel}'");
-                    return Failure();
-                }
+            if (error is null)
+            {
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **`{labelToApply.Label}` applied**", true));
+                resultMessageParts.Add($"Label '{labelToApply.Label}' applied.");
             }
             else
             {
-                return Success();
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying label `{labelToApply.Label}`**: {error}", true));
+                resultMessageParts.Add($"Error occurred applying label '{labelToApply.Label}'");
+                return Failure();
             }
         }
-        else
+
+        if (hasDefaultLabel && defaultLabel is not null)
         {
-            predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying label `{bestScore.Label}`**: {error}", true));
-            resultMessageParts.Add($"Error occurred applying label '{bestScore.Label}'");
-            return Failure();
+            if (!test)
+            {
+                error = await UnapplyLabel(defaultLabel);
+            }
+
+            if (error is null)
+            {
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Removed default label `{defaultLabel}`**", true));
+                resultMessageParts.Add($"Default label '{defaultLabel}' removed.");
+                return Success();
+            }
+            else
+            {
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error removing default label `{defaultLabel}`**: {error}", true));
+                resultMessageParts.Add($"Error occurred removing default label '{defaultLabel}'");
+                return Failure();
+            }
         }
+
+        return Success();
     }
 
     if (defaultLabel is not null)

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -252,10 +252,10 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         .Where(prediction => labelPredicate(prediction.Label))
         // Capture the top max(3, maxLabels) for including in the output
         .OrderByDescending(p => p.Score)
-        .Take(3)
+        .Take(Math.Max(3, argsData.MaxLabels))
         .ToList();
 
-    var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(1).ToList();
+    var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(argsData.MaxLabels).ToList();
 
     if (topLabels.Count > 0)
     {

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -50,7 +50,6 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
             new Issue(result),
             argsData.LabelPredicate,
             argsData.DefaultLabel,
-            argsData.MaxLabels,
             ModelType.Issue,
             argsData.Retries,
             argsData.Test
@@ -89,7 +88,6 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
             new PullRequest(result),
             argsData.LabelPredicate,
             argsData.DefaultLabel,
-            argsData.MaxLabels,
             ModelType.PullRequest,
             argsData.Retries,
             argsData.Test
@@ -131,7 +129,6 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
             new Issue(result),
             argsData.LabelPredicate,
             argsData.DefaultLabel,
-            argsData.MaxLabels,
             ModelType.Discussion,
             argsData.Retries,
             argsData.Test,
@@ -152,7 +149,7 @@ foreach (var prediction in predictionResults.OrderBy(p => p.Number))
 await action.Summary.WritePersistentAsync();
 return success ? 0 : 1;
 
-async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, ulong number, T issueOrPull, Func<string, bool> labelPredicate, string? defaultLabel, int maxLabels, ModelType type, int[] retries, bool test, string? nodeId = null) where T : Issue
+async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, ulong number, T issueOrPull, Func<string, bool> labelPredicate, string? defaultLabel, ModelType type, int[] retries, bool test, string? nodeId = null) where T : Issue
 {
     List<Action<Summary>> predictionResults = [];
     string typeName = type switch
@@ -255,10 +252,10 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         .Where(prediction => labelPredicate(prediction.Label))
         // Capture the top max(3, maxLabels) for including in the output
         .OrderByDescending(p => p.Score)
-        .Take(Math.Max(3, maxLabels))
+        .Take(3)
         .ToList();
 
-    var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(maxLabels).ToList();
+    var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(1).ToList();
 
     if (topLabels.Count > 0)
     {

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -56,7 +56,7 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
             argsData.MaxLabels,
             ModelType.Issue,
             argsData.Retries,
-            argsData.Test
+            argsData.DryRun
         )));
 
         action.WriteInfo($"[Issue {argsData.Org}/{argsData.Repo}#{issueNumber}] Queued for prediction.");
@@ -96,7 +96,7 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
             argsData.MaxLabels,
             ModelType.PullRequest,
             argsData.Retries,
-            argsData.Test
+            argsData.DryRun
         )));
 
         action.WriteInfo($"[Pull Request {argsData.Org}/{argsData.Repo}#{pullNumber}] Queued for prediction.");
@@ -139,7 +139,7 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
             argsData.MaxLabels,
             ModelType.Discussion,
             argsData.Retries,
-            argsData.Test,
+            argsData.DryRun,
             nodeId: result.Id
         )));
 
@@ -160,7 +160,7 @@ pullPredictors?.Dispose();
 await action.Summary.WritePersistentAsync();
 return success ? 0 : 1;
 
-async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, ulong number, T issueOrPull, Func<string, bool> labelPredicate, string? defaultLabel, int maxLabels, ModelType type, int[] retries, bool test, string? nodeId = null) where T : Issue
+async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, ulong number, T issueOrPull, Func<string, bool> labelPredicate, string? defaultLabel, int maxLabels, ModelType type, int[] retries, bool dryRun, string? nodeId = null) where T : Issue
 {
     List<Action<Summary>> predictionResults = [];
     string typeName = type switch
@@ -196,8 +196,8 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
     (ulong, string, bool) Success() => GetResult(true);
     (ulong, string, bool) Failure() => GetResult(false);
 
-    string ApplyVerb() => test ? "would be applied" : "applied";
-    string RemoveVerb() => test ? "would be removed" : "removed";
+    string ApplyVerb() => dryRun ? "would be applied" : "applied";
+    string RemoveVerb() => dryRun ? "would be removed" : "removed";
 
     predictionResults.Add(summary => summary.AddRawMarkdown($"- **{argsData.Org}/{argsData.Repo}#{number}**", true));
 
@@ -228,7 +228,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
 
         if (hasDefaultLabel && defaultLabel is not null)
         {
-            if (!test)
+            if (!dryRun)
             {
                 error = await UnapplyLabel(defaultLabel);
             }
@@ -303,7 +303,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         foreach (var labelToApply in topLabels)
         {
             error = null;
-            if (!test)
+            if (!dryRun)
             {
                 error = await ApplyLabel(labelToApply.Label);
             }
@@ -323,7 +323,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
 
         if (hasDefaultLabel && defaultLabel is not null)
         {
-            if (!test)
+            if (!dryRun)
             {
                 error = await UnapplyLabel(defaultLabel);
             }
@@ -355,7 +355,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         }
         else
         {
-            if (!test)
+            if (!dryRun)
             {
                 error = await ApplyLabel(defaultLabel);
             }

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -96,6 +96,46 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
     }
 }
 
+if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
+{
+    await action.WriteStatusAsync($"Loading prediction engine for discussions (uses issues model)...");
+    var discussionContext = new MLContext();
+    var discussionModel = discussionContext.Model.Load(argsData.IssuesModelPath, out _);
+    var discussionPredictor = discussionContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(discussionModel);
+    await action.WriteStatusAsync($"Discussions prediction engine ready.");
+
+    foreach (ulong discussionNumber in argsData.Discussions)
+    {
+        var result = await GitHubApi.GetDiscussion(argsData.GitHubToken, argsData.Org, argsData.Repo, discussionNumber, argsData.Retries, action, argsData.Verbose);
+
+        if (result is null)
+        {
+            action.WriteNotice($"[Discussion {argsData.Org}/{argsData.Repo}#{discussionNumber}] could not be found or downloaded. Skipped.");
+            continue;
+        }
+
+        if (argsData.ExcludedAuthors is not null && result.Author?.Login is not null && argsData.ExcludedAuthors.Contains(result.Author.Login, StringComparer.InvariantCultureIgnoreCase))
+        {
+            action.WriteNotice($"[Discussion {argsData.Org}/{argsData.Repo}#{discussionNumber}] Author '{result.Author.Login}' is in excluded list. Skipped.");
+            continue;
+        }
+
+        tasks.Add(Task.Run(() => ProcessPrediction(
+            discussionPredictor,
+            result.Number,
+            new Issue(result),
+            argsData.LabelPredicate,
+            argsData.DefaultLabel,
+            ModelType.Discussion,
+            argsData.Retries,
+            argsData.Test,
+            nodeId: result.Id
+        )));
+
+        action.WriteInfo($"[Discussion {argsData.Org}/{argsData.Repo}#{discussionNumber}] Queued for prediction.");
+    }
+}
+
 var (predictionResults, success) = await App.RunTasks(tasks, action);
 
 foreach (var prediction in predictionResults.OrderBy(p => p.Number))
@@ -106,10 +146,26 @@ foreach (var prediction in predictionResults.OrderBy(p => p.Number))
 await action.Summary.WritePersistentAsync();
 return success ? 0 : 1;
 
-async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, ulong number, T issueOrPull, Func<string, bool> labelPredicate, string? defaultLabel, ModelType type, int[] retries, bool test) where T : Issue
+async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, ulong number, T issueOrPull, Func<string, bool> labelPredicate, string? defaultLabel, ModelType type, int[] retries, bool test, string? nodeId = null) where T : Issue
 {
     List<Action<Summary>> predictionResults = [];
-    string typeName = type == ModelType.PullRequest ? "Pull Request" : "Issue";
+    string typeName = type switch
+    {
+        ModelType.PullRequest => "Pull Request",
+        ModelType.Discussion => "Discussion",
+        _ => "Issue"
+    };
+
+    Func<string, Task<string?>> ApplyLabel = label =>
+        type == ModelType.Discussion && nodeId is not null
+            ? GitHubApi.AddLabelToDiscussion(argsData.GitHubToken, argsData.Org, argsData.Repo, nodeId, label, retries, action)
+            : GitHubApi.AddLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, label, retries, action);
+
+    Func<string, Task<string?>> UnapplyLabel = label =>
+        type == ModelType.Discussion && nodeId is not null
+            ? GitHubApi.RemoveLabelFromDiscussion(argsData.GitHubToken, argsData.Org, argsData.Repo, nodeId, label, retries, action)
+            : GitHubApi.RemoveLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, label, retries, action);
+
     List<string> resultMessageParts = [];
     string? error = null;
 
@@ -150,7 +206,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         {
             if (!test)
             {
-                error = await GitHubApi.RemoveLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, argsData.Retries, action);
+                error = await UnapplyLabel(defaultLabel);
             }
 
             if (error is null)
@@ -215,7 +271,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
     {
         if (!test)
         {
-            error = await GitHubApi.AddLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, bestScore.Label, retries, action);
+            error = await ApplyLabel(bestScore.Label);
         }
 
         if (error is null)
@@ -227,7 +283,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
             {
                 if (!test)
                 {
-                    error = await GitHubApi.RemoveLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, retries, action);
+                    error = await UnapplyLabel(defaultLabel);
                 }
 
                 if (error is null)
@@ -268,7 +324,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         {
             if (!test)
             {
-                error = await GitHubApi.AddLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, argsData.Retries, action);
+                error = await ApplyLabel(defaultLabel);
             }
 
             if (error is null)

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -18,11 +18,14 @@ if (Args.Parse(args, action) is not Args argsData) return 1;
 
 List<Task<(ulong Number, string ResultMessage, bool Success)>> tasks = new();
 
+MLContext? issueContext = null;
+ITransformer? issueModel = null;
+
 if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
 {
     await action.WriteStatusAsync($"Loading prediction engine for issues model...");
-    var issueContext = new MLContext();
-    var issueModel = issueContext.Model.Load(argsData.IssuesModelPath, out _);
+    issueContext = new MLContext();
+    issueModel = issueContext.Model.Load(argsData.IssuesModelPath, out _);
     await action.WriteStatusAsync($"Issues prediction engine ready.");
 
     foreach (ulong issueNumber in argsData.Issues)
@@ -98,10 +101,13 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
 
 if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
 {
-    await action.WriteStatusAsync($"Loading prediction engine for discussions (uses issues model)...");
-    var discussionContext = new MLContext();
-    var discussionModel = discussionContext.Model.Load(argsData.IssuesModelPath, out _);
-    await action.WriteStatusAsync($"Discussions prediction engine ready.");
+    if (issueContext is null || issueModel is null)
+    {
+        await action.WriteStatusAsync($"Loading prediction engine for discussions (uses issues model)...");
+        issueContext = new MLContext();
+        issueModel = issueContext.Model.Load(argsData.IssuesModelPath, out _);
+        await action.WriteStatusAsync($"Discussions prediction engine ready.");
+    }
 
     foreach (ulong discussionNumber in argsData.Discussions)
     {
@@ -120,7 +126,7 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
         }
 
         tasks.Add(Task.Run(() => ProcessPrediction(
-            discussionContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(discussionModel),
+            issueContext!.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel!),
             result.Number,
             new Issue(result),
             argsData.LabelPredicate,

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -45,7 +45,7 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
         }
 
         tasks.Add(Task.Run(() => ProcessPrediction(
-            issueContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel),
+            issueContext!.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel!),
             issueNumber,
             new Issue(result),
             argsData.LabelPredicate,

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -272,16 +272,17 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         })
         // Ensure predicted labels match the expected predicate
         .Where(prediction => labelPredicate(prediction.Label))
-        // Capture the top max(3, maxLabels) for including in the output
+        // Capture the top 3 predictions for including in the output
         .OrderByDescending(p => p.Score)
-        .Take(Math.Max(3, argsData.MaxLabels))
+        .Take(3)
         .ToList();
 
-    var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(argsData.MaxLabels).ToList();
+    var eligibleLabels = predictions.Where(p => p.Score >= argsData.Threshold).ToList();
+    var topLabels = eligibleLabels.Take(1).ToList();
 
-    if (topLabels.Count > 0)
+    if (eligibleLabels.Count > 0)
     {
-        predictionResults.Add(summary => summary.AddRawMarkdown($"    - {topLabels.Count} label prediction(s) meet the threshold of {argsData.Threshold}.", true));
+        predictionResults.Add(summary => summary.AddRawMarkdown($"    - {eligibleLabels.Count} label(s) meet the threshold of {argsData.Threshold}; applying {topLabels.Count}.", true));
     }
     else
     {
@@ -295,7 +296,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
 
     if (argsData.Verbose && predictions.Count > 0)
     {
-        resultMessageParts.Add($"Top predictions: {string.Join(", ", predictions.Select(p => $"'{p.Label}'={p.Score:0.000}"))}. Threshold={argsData.Threshold:0.000}; max_labels={argsData.MaxLabels}.");
+        resultMessageParts.Add($"Top predictions: {string.Join(", ", predictions.Select(p => $"'{p.Label}'={p.Score:0.000}"))}. Threshold={argsData.Threshold:0.000}.");
     }
 
     if (topLabels.Count > 0)

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -41,9 +41,6 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
             continue;
         }
 
-        // CreatePredictionEngine is called once per task. ITransformer is shared and thread-safe;
-        // PredictionEngine itself is not, but each Task.Run closure captures its own instance.
-        // Microsoft.Extensions.ML (PredictionEnginePool) is not a dependency of this project.
         tasks.Add(Task.Run(() => ProcessPrediction(
             issueContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(issueModel),
             issueNumber,
@@ -83,7 +80,6 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
             continue;
         }
 
-        // See issues block above: one PredictionEngine per Task.Run, ITransformer shared.
         tasks.Add(Task.Run(() => ProcessPrediction(
             pullContext.Model.CreatePredictionEngine<PullRequest, LabelPrediction>(pullModel),
             pullNumber,
@@ -123,7 +119,6 @@ if (argsData.IssuesModelPath is not null && argsData.Discussions is not null)
             continue;
         }
 
-        // See issues block above: one PredictionEngine per Task.Run, ITransformer shared.
         tasks.Add(Task.Run(() => ProcessPrediction(
             discussionContext.Model.CreatePredictionEngine<Issue, LabelPrediction>(discussionModel),
             result.Number,

--- a/IssueLabeler/src/Tester/Args.cs
+++ b/IssueLabeler/src/Tester/Args.cs
@@ -12,7 +12,9 @@ public struct Args
     public Predicate<string> LabelPredicate { get; set; }
     public string[]? ExcludedAuthors { get; set; }
     public string? IssuesModelPath { get; set; }
+    public bool TestDiscussions { get; set; }
     public int? IssuesLimit { get; set; }
+    public int? DiscussionsLimit { get; set; }
     public string? PullsModelPath { get; set; }
     public int? PullsLimit { get; set; }
     public int? PageSize { get; set; }
@@ -34,6 +36,7 @@ public struct Args
 
             Required for testing the issues model:
               --issues-model          Path to existing issue prediction model file (ZIP file).
+                            --discussions          Evaluate discussions using the issue prediction model.
 
             Required for testing the pull requests model:
               --pulls-model           Path to existing pull request prediction model file (ZIP file).
@@ -43,6 +46,7 @@ public struct Args
               --threshold             Minimum prediction confidence threshold. Range (0,1].
                                       Defaults to: 0.4.
               --issues-limit          Maximum number of issues to download. Defaults to: No limit.
+              --discussions-limit     Maximum number of discussions to download. Defaults to: No limit.
               --pulls-limit           Maximum number of pull requests to download. Defaults to: No limit.
               --page-size             Number of items per page in GitHub API requests.
                                       Defaults to: 100 for issues, 25 for pull requests.
@@ -120,12 +124,24 @@ public struct Args
                     argsData.IssuesModelPath = IssuesModelPath;
                     break;
 
+                case "--discussions":
+                    argsData.TestDiscussions = true;
+                    break;
+
                 case "--issues-limit":
                     if (!argUtils.TryGetInt("--issues-limit", out int? IssuesLimit))
                     {
                         return null;
                     }
                     argsData.IssuesLimit = IssuesLimit;
+                    break;
+
+                case "--discussions-limit":
+                    if (!argUtils.TryGetInt("--discussions-limit", out int? discussionsLimit))
+                    {
+                        return null;
+                    }
+                    argsData.DiscussionsLimit = discussionsLimit;
                     break;
 
                 case "--pulls-model":

--- a/IssueLabeler/src/Tester/Args.cs
+++ b/IssueLabeler/src/Tester/Args.cs
@@ -36,7 +36,7 @@ public struct Args
 
             Required for testing the issues model:
               --issues-model          Path to existing issue prediction model file (ZIP file).
-                            --discussions           Also evaluate discussions using the issues prediction model.
+              --discussions           Also evaluate discussions using the issues prediction model.
 
             Required for testing the pull requests model:
               --pulls-model           Path to existing pull request prediction model file (ZIP file).

--- a/IssueLabeler/src/Tester/Args.cs
+++ b/IssueLabeler/src/Tester/Args.cs
@@ -36,7 +36,7 @@ public struct Args
 
             Required for testing the issues model:
               --issues-model          Path to existing issue prediction model file (ZIP file).
-                            --discussions          Evaluate discussions using the issue prediction model.
+                            --discussions           Evaluate discussions using the issue prediction model.
 
             Required for testing the pull requests model:
               --pulls-model           Path to existing pull request prediction model file (ZIP file).
@@ -198,6 +198,12 @@ public struct Args
             (argsData.IssuesModelPath is null && argsData.PullsModelPath is null))
         {
             ShowUsage(null, action);
+            return null;
+        }
+
+        if (argsData.TestDiscussions && argsData.IssuesModelPath is null)
+        {
+            ShowUsage("Argument '--issues-model' is required when '--discussions' is provided.", action);
             return null;
         }
 

--- a/IssueLabeler/src/Tester/Args.cs
+++ b/IssueLabeler/src/Tester/Args.cs
@@ -36,7 +36,7 @@ public struct Args
 
             Required for testing the issues model:
               --issues-model          Path to existing issue prediction model file (ZIP file).
-                            --discussions           Evaluate discussions using the issue prediction model.
+                            --discussions           Also evaluate discussions using the issues prediction model.
 
             Required for testing the pull requests model:
               --pulls-model           Path to existing pull request prediction model file (ZIP file).

--- a/IssueLabeler/src/Tester/Models.cs
+++ b/IssueLabeler/src/Tester/Models.cs
@@ -14,6 +14,11 @@ public class Issue
     public string? Area { get => Label; }
     public string? Description { get => Body; }
 
+    protected Issue()
+    {
+        Repo = string.Empty;
+    }
+
     public Issue(string repo, GitHubClient.Issue issue, Predicate<string> labelPredicate)
     {
         Repo = repo;
@@ -35,6 +40,20 @@ public class PullRequest : Issue
     {
         FileNames = string.Join(' ', pull.FileNames);
         FolderNames = string.Join(' ', pull.FolderNames);
+    }
+}
+
+public class Discussion : Issue
+{
+    public Discussion(string repo, GitHubClient.Discussion discussion, Predicate<string> labelPredicate)
+    {
+        Repo = repo;
+        Number = discussion.Number;
+        Title = discussion.Title;
+        Body = discussion.Body;
+        Label = discussion.Labels.HasNextPage ?
+            (string?)null :
+            discussion.LabelNames?.SingleOrDefault(l => labelPredicate(l));
     }
 }
 

--- a/IssueLabeler/src/Tester/Models.cs
+++ b/IssueLabeler/src/Tester/Models.cs
@@ -45,15 +45,21 @@ public class PullRequest : Issue
 
 public class Discussion : Issue
 {
-    public Discussion(string repo, GitHubClient.Discussion discussion, Predicate<string> labelPredicate)
+    public Discussion(string repo, GitHubClient.Discussion discussion, string? label)
     {
         Repo = repo;
         Number = discussion.Number;
         Title = discussion.Title;
         Body = discussion.Body;
-        Label = discussion.Labels.HasNextPage ?
-            (string?)null :
-            discussion.LabelNames?.SingleOrDefault(l => labelPredicate(l));
+        Label = label;
+    }
+
+    public Discussion(string repo, GitHubClient.Discussion discussion, Predicate<string> labelPredicate)
+        : this(
+            repo,
+            discussion,
+            discussion.Labels.HasNextPage ? (string?)null : discussion.LabelNames?.SingleOrDefault(l => labelPredicate(l)))
+    {
     }
 }
 

--- a/IssueLabeler/src/Tester/Tester.cs
+++ b/IssueLabeler/src/Tester/Tester.cs
@@ -20,7 +20,7 @@ if (config is not Args argsData) return 1;
 
 List<Task<(Type ItemType, TestStats Stats)>> tasks = [];
 
-if (argsData.IssuesModelPath is not null && !argsData.TestDiscussions)
+if (argsData.IssuesModelPath is not null)
 {
     tasks.Add(Task.Run(() => TestIssues()));
 }
@@ -40,7 +40,7 @@ var (results, success) = await App.RunTasks(tasks, action);
 foreach (var (itemType, stats) in results)
 {
     AlertType resultAlert = (stats.MatchesPercentage >= 0.65f && stats.MismatchesPercentage < 0.15f) ? AlertType.Note : AlertType.Warning;
-    string itemTypeName = GetItemTypeName(itemType);
+    string itemTypeName = GetItemTypeNamePlural(itemType);
 
     action.Summary.AddPersistent(summary =>
     {
@@ -205,7 +205,7 @@ PredictionEngine<T, LabelPrediction> GetPredictionEngine<T>(string modelPath) wh
 
 void TestPrediction<T>(T result, PredictionEngine<T, LabelPrediction> predictor, TestStats stats) where T : Issue
 {
-    var itemType = GetSingularItemTypeName(typeof(T));
+    var itemType = GetItemTypeNameSingular(typeof(T));
 
     (string? predictedLabel, float? score) = GetPrediction(
         predictor,
@@ -251,7 +251,7 @@ void TestPrediction<T>(T result, PredictionEngine<T, LabelPrediction> predictor,
 (string? PredictedLabel, float? PredictionScore) GetPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, T issueOrPull, float? threshold) where T : Issue
 {
     var prediction = predictor.Predict(issueOrPull);
-    var itemType = GetSingularItemTypeName(typeof(T));
+    var itemType = GetItemTypeNameSingular(typeof(T));
 
     if (prediction.Score is null || prediction.Score.Length == 0)
     {
@@ -274,7 +274,7 @@ void TestPrediction<T>(T result, PredictionEngine<T, LabelPrediction> predictor,
     return bestScore is not null ? (bestScore.Label, bestScore.Score) : ((string?)null, (float?)null);
 }
 
-static string GetItemTypeName(Type type)
+static string GetItemTypeNamePlural(Type type)
 {
     if (type == typeof(PullRequest))
     {
@@ -289,7 +289,7 @@ static string GetItemTypeName(Type type)
     return "Issues";
 }
 
-static string GetSingularItemTypeName(Type type)
+static string GetItemTypeNameSingular(Type type)
 {
     if (type == typeof(PullRequest))
     {

--- a/IssueLabeler/src/Tester/Tester.cs
+++ b/IssueLabeler/src/Tester/Tester.cs
@@ -131,7 +131,7 @@ async Task<(Type, TestStats)> TestDiscussions()
     {
         await foreach (var result in GitHubApi.DownloadDiscussions(githubToken, argsData.Org, repo, argsData.LabelPredicate, argsData.DiscussionsLimit, argsData.PageSize, argsData.PageLimit, argsData.Retries, argsData.ExcludedAuthors, action, argsData.Verbose))
         {
-            yield return new(repo, result.Discussion, argsData.LabelPredicate);
+            yield return new(repo, result.Discussion, result.Label);
         }
     }
 

--- a/IssueLabeler/src/Tester/Tester.cs
+++ b/IssueLabeler/src/Tester/Tester.cs
@@ -20,9 +20,14 @@ if (config is not Args argsData) return 1;
 
 List<Task<(Type ItemType, TestStats Stats)>> tasks = [];
 
-if (argsData.IssuesModelPath is not null)
+if (argsData.IssuesModelPath is not null && !argsData.TestDiscussions)
 {
     tasks.Add(Task.Run(() => TestIssues()));
+}
+
+if (argsData.IssuesModelPath is not null && argsData.TestDiscussions)
+{
+    tasks.Add(Task.Run(() => TestDiscussions()));
 }
 
 if (argsData.PullsModelPath is not null)
@@ -35,10 +40,11 @@ var (results, success) = await App.RunTasks(tasks, action);
 foreach (var (itemType, stats) in results)
 {
     AlertType resultAlert = (stats.MatchesPercentage >= 0.65f && stats.MismatchesPercentage < 0.15f) ? AlertType.Note : AlertType.Warning;
+    string itemTypeName = GetItemTypeName(itemType);
 
     action.Summary.AddPersistent(summary =>
     {
-        summary.AddMarkdownHeading($"Finished Testing {(itemType == typeof(PullRequest) ? "Pull Requests" : "Issues")}", 2);
+        summary.AddMarkdownHeading($"Finished Testing {itemTypeName}", 2);
         summary.AddAlert($"**{stats.Total}** items were tested with **{stats.MatchesPercentage:P2} matches** and **{stats.MismatchesPercentage:P2} mismatches**.", resultAlert);
         summary.AddRawMarkdown($"Testing complete. **{stats.Total}** items tested, with the following results.", true);
         summary.AddNewLine();
@@ -116,6 +122,36 @@ async Task<(Type, TestStats)> TestIssues()
     return (typeof(Issue), stats);
 }
 
+async Task<(Type, TestStats)> TestDiscussions()
+{
+    var predictor = GetPredictionEngine<Discussion>(argsData.IssuesModelPath!);
+    var stats = new TestStats();
+
+    async IAsyncEnumerable<Discussion> DownloadDiscussions(string githubToken, string repo)
+    {
+        await foreach (var result in GitHubApi.DownloadDiscussions(githubToken, argsData.Org, repo, argsData.LabelPredicate, argsData.DiscussionsLimit, argsData.PageSize, argsData.PageLimit, argsData.Retries, argsData.ExcludedAuthors, action, argsData.Verbose))
+        {
+            yield return new(repo, result.Discussion, argsData.LabelPredicate);
+        }
+    }
+
+    action.WriteInfo($"Testing discussions from {argsData.Repos.Count} repositories.");
+
+    foreach (var repo in argsData.Repos)
+    {
+        await action.WriteStatusAsync($"Downloading and testing discussions from {argsData.Org}/{repo}.");
+
+        await foreach (var discussion in DownloadDiscussions(argsData.GitHubToken, repo))
+        {
+            TestPrediction(discussion, predictor, stats);
+        }
+
+        await action.WriteStatusAsync($"Finished Testing Discussions from {argsData.Org}/{repo}.");
+    }
+
+    return (typeof(Discussion), stats);
+}
+
 async Task<(Type, TestStats)> TestPullRequests()
 {
     var predictor = GetPredictionEngine<PullRequest>(argsData.PullsModelPath);
@@ -169,7 +205,7 @@ PredictionEngine<T, LabelPrediction> GetPredictionEngine<T>(string modelPath) wh
 
 void TestPrediction<T>(T result, PredictionEngine<T, LabelPrediction> predictor, TestStats stats) where T : Issue
 {
-    var itemType = typeof(T) == typeof(PullRequest) ? "Pull Request" : "Issue";
+    var itemType = GetSingularItemTypeName(typeof(T));
 
     (string? predictedLabel, float? score) = GetPrediction(
         predictor,
@@ -215,7 +251,7 @@ void TestPrediction<T>(T result, PredictionEngine<T, LabelPrediction> predictor,
 (string? PredictedLabel, float? PredictionScore) GetPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, T issueOrPull, float? threshold) where T : Issue
 {
     var prediction = predictor.Predict(issueOrPull);
-    var itemType = typeof(T) == typeof(PullRequest) ? "Pull Request" : "Issue";
+    var itemType = GetSingularItemTypeName(typeof(T));
 
     if (prediction.Score is null || prediction.Score.Length == 0)
     {
@@ -236,6 +272,36 @@ void TestPrediction<T>(T result, PredictionEngine<T, LabelPrediction> predictor,
         .FirstOrDefault(p => threshold is null || p.Score >= threshold);
 
     return bestScore is not null ? (bestScore.Label, bestScore.Score) : ((string?)null, (float?)null);
+}
+
+static string GetItemTypeName(Type type)
+{
+    if (type == typeof(PullRequest))
+    {
+        return "Pull Requests";
+    }
+
+    if (type == typeof(Discussion))
+    {
+        return "Discussions";
+    }
+
+    return "Issues";
+}
+
+static string GetSingularItemTypeName(Type type)
+{
+    if (type == typeof(PullRequest))
+    {
+        return "Pull Request";
+    }
+
+    if (type == typeof(Discussion))
+    {
+        return "Discussion";
+    }
+
+    return "Issue";
 }
 
 class TestStats

--- a/download/action.yml
+++ b/download/action.yml
@@ -1,5 +1,5 @@
 name: "Download Data"
-description: "Download GitHub issues or pull requests and cache the data."
+description: "Download GitHub issues, discussions, or pull requests and cache the data."
 
 branding:
   color: "purple"
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   type:
-    description: "The type of data to download. Must be either 'issues' or 'pulls'."
+    description: "The type of data to download. Must be 'issues', 'discussions', or 'pulls'."
     required: true
   label_prefix:
     description: "The label prefix to be used for model training. Must end in a non-alphanumeric character."
@@ -34,10 +34,10 @@ runs:
     - name: "Validate inputs and set cache variables"
       shell: bash
       run: |
-        if [[ "${{ inputs.type }}" != "issues" && "${{ inputs.type }}" != "pulls" ]]; then
-          echo "::error::'type' must be either 'issues' or 'pulls'. Value provided: '${{ inputs.type }}'"
+        if [[ "${{ inputs.type }}" != "issues" && "${{ inputs.type }}" != "discussions" && "${{ inputs.type }}" != "pulls" ]]; then
+          echo "::error::'type' must be either 'issues', 'discussions', or 'pulls'. Value provided: '${{ inputs.type }}'"
           echo "> [!CAUTION]" >> $GITHUB_STEP_SUMMARY
-          echo "\`type\` must be either 'issues' or 'pulls'." >> $GITHUB_STEP_SUMMARY
+          echo "\`type\` must be either 'issues', 'discussions', or 'pulls'." >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
 
@@ -66,15 +66,6 @@ runs:
           exit 1
         fi
 
-    - name: "Clone the ${{ github.action_repository }} repository with ref '{{ github.action_ref }}'"
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      env:
-        ISSUE_LABELER_REPO: ${{ github.action_repository }}
-        ISSUE_LABELER_REF: ${{ github.action_ref }}
-      with:
-        repository: ${{ env.ISSUE_LABELER_REPO }}
-        ref: ${{ env.ISSUE_LABELER_REF }}
-
     - name: "Set up the .NET SDK"
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
@@ -83,7 +74,7 @@ runs:
     - name: "Run Downloader"
       shell: bash
       run: |
-        dotnet run -c Release --project IssueLabeler/src/Downloader -- \
+        dotnet run -c Release --project "${{ github.action_path }}/../IssueLabeler/src/Downloader" -- \
           ${{ format('--repo "{0}"', inputs.repository || github.repository) }} \
           ${{ format('--label-prefix "{0}"', inputs.label_prefix) }} \
           ${{ format('--{0}-data "{1}"', inputs.type, env.DATA_PATH) }} \
@@ -103,5 +94,5 @@ runs:
       shell: bash
       run: |
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## ${{ inputs.type == 'issues' && 'Issues' || 'Pull Requests' }} Data Available as '${{ inputs.cache_key }}'" >> $GITHUB_STEP_SUMMARY
+        echo "## ${{ inputs.type == 'issues' && 'Issues' || inputs.type == 'discussions' && 'Discussions' || 'Pull Requests' }} Data Available as '${{ inputs.cache_key }}'" >> $GITHUB_STEP_SUMMARY
         echo "The '${{ inputs.cache_key }}' data is saved to cache and available for training a model." >> $GITHUB_STEP_SUMMARY

--- a/download/action.yml
+++ b/download/action.yml
@@ -35,9 +35,9 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.type }}" != "issues" && "${{ inputs.type }}" != "discussions" && "${{ inputs.type }}" != "pulls" ]]; then
-          echo "::error::'type' must be either 'issues', 'discussions', or 'pulls'. Value provided: '${{ inputs.type }}'"
+          echo "::error::'type' must be one of 'issues', 'discussions', or 'pulls'. Value provided: '${{ inputs.type }}'"
           echo "> [!CAUTION]" >> $GITHUB_STEP_SUMMARY
-          echo "\`type\` must be either 'issues', 'discussions', or 'pulls'." >> $GITHUB_STEP_SUMMARY
+          echo "\`type\` must be one of 'issues', 'discussions', or 'pulls'." >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
 

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -24,11 +24,6 @@ inputs:
     required: false
     default: "0.40"
 
-  max_labels:
-    description: "The maximum number of labels to apply when predictions meet the threshold. Defaults to 1."
-    required: false
-    default: "1"
-
   default_label:
     description: "The default label to apply if no prediction meets the threshold. Leave blank for no default label."
 

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -51,7 +51,7 @@ runs:
   using: docker
   # Reference the docker container image using a published sha256 digest
   # to ensure an immutable version is always used.
-  image: docker://ghcr.io/swathipil/issue-labeler/predictor@sha256:a203124510964a2928a39a39b20a5cfd4517e879cd497817fcbe52059aad54e8 # temp/discussion-labeling-release
+  image: docker://ghcr.io/dotnet/issue-labeler/predictor@sha256:<sha256-digest-to-be-added-here-after-first-release>
   env:
     INPUT_ISSUES_MODEL: "labeler-cache/issues-model.zip"
     INPUT_PULLS_MODEL: "labeler-cache/pulls-model.zip"

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -56,7 +56,7 @@ runs:
   using: docker
   # Reference the docker container image using a published sha256 digest
   # to ensure an immutable version is always used.
-  image: docker://ghcr.io/dotnet/issue-labeler/predictor@sha256:<sha256-digest-to-be-added-here-after-first-release>
+  image: docker://ghcr.io/swathipil/issue-labeler/predictor:temp-discussion-labeling-release # temp/discussion-labeling-release
   env:
     INPUT_ISSUES_MODEL: "labeler-cache/issues-model.zip"
     INPUT_PULLS_MODEL: "labeler-cache/pulls-model.zip"

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -56,7 +56,7 @@ runs:
   using: docker
   # Reference the docker container image using a published sha256 digest
   # to ensure an immutable version is always used.
-  image: docker://ghcr.io/swathipil/issue-labeler/predictor:temp-discussion-labeling-release # temp/discussion-labeling-release
+  image: docker://ghcr.io/swathipil/issue-labeler/predictor@sha256:a203124510964a2928a39a39b20a5cfd4517e879cd497817fcbe52059aad54e8 # temp/discussion-labeling-release
   env:
     INPUT_ISSUES_MODEL: "labeler-cache/issues-model.zip"
     INPUT_PULLS_MODEL: "labeler-cache/pulls-model.zip"

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -1,5 +1,5 @@
 name: "Predict Labels"
-description: "Predict labels for Issues, Pull Requests, and Discussions using models already restored from cache."
+description: "Predict labels for Issues, Pull Requests, and Discussions using models already restored from cache. At least one of 'issues', 'pulls', or 'discussions' must be provided."
 
 inputs:
   issues:

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -1,14 +1,23 @@
 name: "Predict Labels"
-description: "Predict labels for Issues and Pull Requests using models already restored from cache."
+description: "Predict labels for Issues, Pull Requests, and Discussions using models already restored from cache."
 
 inputs:
   issues:
     description: "Issue Numbers (comma-separated list of ranges)."
-    required: true
+    required: false
 
   pulls:
     description: "Pull Request Numbers (comma-separated list of ranges)."
-    required: true
+    required: false
+
+  discussions:
+    description: "Discussion Numbers (comma-separated list of ranges). Uses the issues model for prediction."
+    required: false
+
+  max_labels:
+    description: "Maximum number of labels to apply when multiple predictions meet the threshold. Must be a positive integer in [1, 5]. Defaults to 1."
+    required: false
+    default: "1"
 
   label_prefix:
     description: "The label prefix used for prediction. Must end with a non-alphanumeric character. Defaults to 'area-'."

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -35,8 +35,12 @@ inputs:
     required: false
     default: "30,30,300,300,3000,3000"
 
+  dry_run:
+    description: "Run in dry-run mode, outputting predictions without applying labels."
+    required: false
+
   test:
-    description: "Run in test mode, outputting predictions without applying labels."
+    description: "Deprecated alias for `dry_run`. Run in dry-run mode, outputting predictions without applying labels."
     required: false
 
   verbose:

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -14,11 +14,6 @@ inputs:
     description: "Discussion Numbers (comma-separated list of ranges). Uses the issues model for prediction."
     required: false
 
-  max_labels:
-    description: "Maximum number of labels to apply when multiple predictions meet the threshold. Must be a positive integer in [1, 5]. Defaults to 1."
-    required: false
-    default: "1"
-
   label_prefix:
     description: "The label prefix used for prediction. Must end with a non-alphanumeric character. Defaults to 'area-'."
     required: false

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -24,6 +24,11 @@ inputs:
     required: false
     default: "0.40"
 
+  max_labels:
+    description: "The maximum number of labels to apply when predictions meet the threshold. Defaults to 1."
+    required: false
+    default: "1"
+
   default_label:
     description: "The default label to apply if no prediction meets the threshold. Leave blank for no default label."
 

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -3,7 +3,7 @@ description: "Restore a model from cache for label prediction or cache retention
 
 inputs:
   type:
-    description: "The model to restore. Must be 'issues', 'discussions', or 'pulls'. Discussions use the issue-like model path."
+    description: "The model to restore. Must be 'issues', 'discussions', or 'pulls'. Each type restores its own cached model file."
     required: true
 
   cache_key:
@@ -44,7 +44,7 @@ runs:
       id: restore-cache
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        path: "labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || inputs.type == 'discussions' && 'discussions' || 'issues' }}-model.zip"
+        path: "labeler-cache/${{ inputs.type }}-model.zip"
         key: "issue-labeler/model/${{ inputs.type }}/${{ inputs.cache_key || 'ACTIVE' }}"
         fail-on-cache-miss: false
 

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -36,7 +36,7 @@ runs:
         if [[ "${{ inputs.type }}" != "issues" && "${{ inputs.type }}" != "discussions" && "${{ inputs.type }}" != "pulls" ]]; then
           echo "::error::'type' must be 'issues', 'discussions', or 'pulls'. Value provided: '${{ inputs.type }}'."
           echo "> [!CAUTION]" >> $GITHUB_STEP_SUMMARY
-          echo "\`type\` must be 'Issues', 'Discussions', or 'Pull Requests'." >> $GITHUB_STEP_SUMMARY
+          echo "\`type\` must be 'issues', 'discussions', or 'pulls'." >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
 

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -3,7 +3,7 @@ description: "Restore a model from cache for label prediction or cache retention
 
 inputs:
   type:
-    description: "The model to restore. Must be 'issues' or 'pulls'."
+    description: "The model to restore. Must be 'issues', 'discussions', or 'pulls'. Discussions use the issue-like model path."
     required: true
 
   cache_key:
@@ -33,10 +33,10 @@ runs:
     - name: "Validate Inputs"
       shell: bash
       run: |
-        if [[ "${{ inputs.type }}" != "issues" && "${{ inputs.type }}" != "pulls" ]]; then
-          echo "::error::'type' must be either 'issues' or 'pulls'. Value provided: '${{ inputs.type }}'."
+        if [[ "${{ inputs.type }}" != "issues" && "${{ inputs.type }}" != "discussions" && "${{ inputs.type }}" != "pulls" ]]; then
+          echo "::error::'type' must be 'issues', 'discussions', or 'pulls'. Value provided: '${{ inputs.type }}'."
           echo "> [!CAUTION]" >> $GITHUB_STEP_SUMMARY
-          echo "\`type\` must be either 'Issues' or 'Pull Requests'." >> $GITHUB_STEP_SUMMARY
+          echo "\`type\` must be 'Issues', 'Discussions', or 'Pull Requests'." >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
 
@@ -44,7 +44,7 @@ runs:
       id: restore-cache
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        path: "labeler-cache/${{ inputs.type }}-model.zip"
+        path: "labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || 'issues' }}-model.zip"
         key: "issue-labeler/model/${{ inputs.type }}/${{ inputs.cache_key || 'ACTIVE' }}"
         fail-on-cache-miss: false
 
@@ -54,10 +54,10 @@ runs:
       run: |
         if [[ "${{ steps.restore-cache.outputs.cache-hit }}" == "true" ]]; then
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
-          echo "> The ${{ inputs.type == 'issues' && 'Issues' || 'Pull Requests' }} model was successfully restored from cache." >> $GITHUB_STEP_SUMMARY
+          echo "> The ${{ inputs.type == 'issues' && 'Issues' || inputs.type == 'discussions' && 'Discussions' || 'Pull Requests' }} model was successfully restored from cache." >> $GITHUB_STEP_SUMMARY
         else
           echo "> [!CAUTION]" >> $GITHUB_STEP_SUMMARY
-          echo "> The ${{ inputs.type == 'issues' && 'Issues' || 'Pull Requests' }} model was not restored from cache. Label prediction cannot proceed." >> $GITHUB_STEP_SUMMARY
+          echo "> The ${{ inputs.type == 'issues' && 'Issues' || inputs.type == 'discussions' && 'Discussions' || 'Pull Requests' }} model was not restored from cache. Label prediction cannot proceed." >> $GITHUB_STEP_SUMMARY
 
           if [[ "${{ inputs.fail-on-cache-miss }}" != "true" ]]; then
             echo "> The workflow is gracefully exiting without failure." >> $GITHUB_STEP_SUMMARY

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -44,7 +44,7 @@ runs:
       id: restore-cache
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        path: "labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || 'issues' }}-model.zip"
+        path: "labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || inputs.type == 'discussions' && 'discussions' || 'issues' }}-model.zip"
         key: "issue-labeler/model/${{ inputs.type }}/${{ inputs.cache_key || 'ACTIVE' }}"
         fail-on-cache-miss: false
 

--- a/test/action.yml
+++ b/test/action.yml
@@ -1,5 +1,5 @@
 name: "Test Model"
-description: "Test predictions against the Issues and/or Pull Requests model by downloading data and comparing predictions against existing labels."
+description: "Test predictions against the Issues, Discussions, and/or Pull Requests model by downloading data and comparing predictions against existing labels."
 
 branding:
   color: "purple"
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   type:
-    description: "The model to test. Must be either 'issues' or 'pulls'."
+    description: "The model to test. Must be 'issues', 'discussions', or 'pulls'. Discussions use the issue-like model path."
     required: true
   label_prefix:
     description: "The label prefix to use for model training. Must end with a non-alphanumeric character."
@@ -39,26 +39,17 @@ runs:
     - name: "Validate Inputs"
       shell: bash
       run: |
-        if [[ "${{ inputs.type }}" != "issues" && "${{ inputs.type }}" != "pulls" ]]; then
-          echo "::error::'type' must be either 'issues' or 'pulls'. Value provided: '${{ inputs.type }}'."
+        if [[ "${{ inputs.type }}" != "issues" && "${{ inputs.type }}" != "discussions" && "${{ inputs.type }}" != "pulls" ]]; then
+          echo "::error::'type' must be 'issues', 'discussions', or 'pulls'. Value provided: '${{ inputs.type }}'."
           echo "> [!CAUTION]" >> $GITHUB_STEP_SUMMARY
-          echo "\`type\` must be either 'issues' or 'pulls'." >> $GITHUB_STEP_SUMMARY
+          echo "\`type\` must be 'issues', 'discussions', or 'pulls'." >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
-
-    - name: "Clone the ${{ github.action_repository }} repository with ref '{{ github.action_ref }}'"
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      env:
-        ISSUE_LABELER_REPO: ${{ github.action_repository }}
-        ISSUE_LABELER_REF: ${{ github.action_ref }}
-      with:
-        repository: ${{ env.ISSUE_LABELER_REPO }}
-        ref: ${{ env.ISSUE_LABELER_REF }}
 
     - name: "Restore model from cache"
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        path: "labeler-cache/${{ inputs.type }}-model.zip"
+        path: "labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || 'issues' }}-model.zip"
         key: "issue-labeler/model/${{ inputs.type }}/${{ inputs.cache_key || 'staged' }}"
         fail-on-cache-miss: true
 
@@ -70,11 +61,12 @@ runs:
     - name: "Run Tester"
       shell: bash
       run: |
-        dotnet run -c Release --project IssueLabeler/src/Tester --  \
+        dotnet run -c Release --project "${{ github.action_path }}/../IssueLabeler/src/Tester" --  \
           ${{ format('--repo "{0}"', inputs.repository || github.repository) }} \
           ${{ format('--label-prefix "{0}"', inputs.label_prefix) }} \
           ${{ format('--threshold {0}', inputs.threshold) }} \
-          ${{ format('--{0}-model "labeler-cache/{0}-model.zip"', inputs.type) || '' }} \
+          ${{ inputs.type == 'pulls' && '--pulls-model "labeler-cache/pulls-model.zip"' || '--issues-model "labeler-cache/issues-model.zip"' }} \
+          ${{ inputs.type == 'discussions' && '--discussions' || '' }} \
           ${{ inputs.excluded_authors && format('--excluded-authors "{0}"', inputs.excluded_authors) || '' }} \
           ${{ inputs.limit && format('--{0}-limit {1}', inputs.type, inputs.limit) || '' }} \
           ${{ inputs.page_size && format('--page-size {0}', inputs.page_size) || '' }} \

--- a/test/action.yml
+++ b/test/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   type:
-    description: "The model to test. Must be 'issues', 'discussions', or 'pulls'. Discussions use the issue-like model path."
+    description: "The model to test. Must be 'issues', 'discussions', or 'pulls'. Discussions use the issues model path."
     required: true
   label_prefix:
     description: "The label prefix to use for model training. Must end with a non-alphanumeric character."

--- a/test/action.yml
+++ b/test/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: "Restore model from cache"
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        path: "labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || 'issues' }}-model.zip"
+        path: "labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || inputs.type == 'discussions' && 'discussions' || 'issues' }}-model.zip"
         key: "issue-labeler/model/${{ inputs.type }}/${{ inputs.cache_key || 'staged' }}"
         fail-on-cache-miss: true
 
@@ -65,7 +65,7 @@ runs:
           ${{ format('--repo "{0}"', inputs.repository || github.repository) }} \
           ${{ format('--label-prefix "{0}"', inputs.label_prefix) }} \
           ${{ format('--threshold {0}', inputs.threshold) }} \
-          ${{ inputs.type == 'pulls' && '--pulls-model "labeler-cache/pulls-model.zip"' || '--issues-model "labeler-cache/issues-model.zip"' }} \
+          ${{ inputs.type == 'pulls' && '--pulls-model "labeler-cache/pulls-model.zip"' || inputs.type == 'discussions' && '--issues-model "labeler-cache/discussions-model.zip"' || '--issues-model "labeler-cache/issues-model.zip"' }} \
           ${{ inputs.type == 'discussions' && '--discussions' || '' }} \
           ${{ inputs.excluded_authors && format('--excluded-authors "{0}"', inputs.excluded_authors) || '' }} \
           ${{ inputs.limit && format('--{0}-limit {1}', inputs.type, inputs.limit) || '' }} \

--- a/train/action.yml
+++ b/train/action.yml
@@ -1,9 +1,9 @@
 name: "Train Model"
-description: "Train the Issues or Pull Requests model for label prediction."
+description: "Train the Issues, Discussions, or Pull Requests model for label prediction. Discussions use the issue-like model path."
 
 inputs:
   type:
-    description: "The model to train. Must be either 'issues' or 'pulls'."
+    description: "The model to train. Must be 'issues', 'discussions', or 'pulls'. Discussions use the issue-like trainer path."
     required: true
   data_cache_key:
     description: "The cache key suffix to use for the downloaded data. Defaults to 'staged'."
@@ -22,10 +22,10 @@ runs:
     - name: "Validate Inputs"
       shell: bash
       run: |
-        if [[ "${{ inputs.type }}" != "issues" && "${{ inputs.type }}" != "pulls" ]]; then
-          echo "::error::'type' must be either 'issues' or 'pulls'. Value provided: '${{ inputs.type }}'."
+        if [[ "${{ inputs.type }}" != "issues" && "${{ inputs.type }}" != "discussions" && "${{ inputs.type }}" != "pulls" ]]; then
+          echo "::error::'type' must be 'issues', 'discussions', or 'pulls'. Value provided: '${{ inputs.type }}'."
           echo "> [!CAUTION]" >> $GITHUB_STEP_SUMMARY
-          echo "\`type\` must be either 'issues' or 'pulls'." >> $GITHUB_STEP_SUMMARY
+          echo "\`type\` must be 'issues', 'discussions', or 'pulls'." >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
 
@@ -34,7 +34,7 @@ runs:
       run: |
         echo "DATA_PATH=labeler-cache/${{ inputs.type }}-data.tsv" >> $GITHUB_ENV
         echo "DATA_CACHE_KEY=${{ format('issue-labeler/data/{0}/{1}', inputs.type, inputs.data_cache_key) }}" >> $GITHUB_ENV
-        echo "MODEL_PATH=labeler-cache/${{ inputs.type }}-model.zip" >> $GITHUB_ENV
+        echo "MODEL_PATH=labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || 'issues' }}-model.zip" >> $GITHUB_ENV
         echo "MODEL_CACHE_KEY=${{ format('issue-labeler/model/{0}/{1}', inputs.type, inputs.model_cache_key) }}" >> $GITHUB_ENV
 
     - name: "Check for an existing model"
@@ -58,15 +58,6 @@ runs:
           exit 1
         fi
 
-    - name: "Clone the ${{ github.action_repository }} repository with ref '{{ github.action_ref }}'"
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      env:
-        ISSUE_LABELER_REPO: ${{ github.action_repository }}
-        ISSUE_LABELER_REF: ${{ github.action_ref }}
-      with:
-        repository: ${{ env.ISSUE_LABELER_REPO }}
-        ref: ${{ env.ISSUE_LABELER_REF }}
-
     - name: "Restore Data from Cache"
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
@@ -82,9 +73,9 @@ runs:
     - name: "Run Trainer"
       shell: bash
       run: |
-        dotnet run -c Release --project IssueLabeler/src/Trainer -- \
-          ${{ format('--{0}-data "{1}"', inputs.type, env.DATA_PATH) }} \
-          ${{ format('--{0}-model "{1}"', inputs.type, env.MODEL_PATH) }}
+        dotnet run -c Release --project "${{ github.action_path }}/../IssueLabeler/src/Trainer" -- \
+          ${{ inputs.type == 'pulls' && format('--pulls-data "{0}"', env.DATA_PATH) || format('--issues-data "{0}"', env.DATA_PATH) }} \
+          ${{ inputs.type == 'pulls' && format('--pulls-model "{0}"', env.MODEL_PATH) || format('--issues-model "{0}"', env.MODEL_PATH) }}
 
     - name: "Save Model to Cache"
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -96,7 +87,7 @@ runs:
       shell: bash
       run: |
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## ${{ inputs.type == 'issues' && 'Issues' || 'Pull Requests' }} Model Available as '${{ inputs.model_cache_key }}'." >> $GITHUB_STEP_SUMMARY
+        echo "## ${{ inputs.type == 'issues' && 'Issues' || inputs.type == 'discussions' && 'Discussions' || 'Pull Requests' }} Model Available as '${{ inputs.model_cache_key }}'." >> $GITHUB_STEP_SUMMARY
 
         if [[ "${{ inputs.model_cache_key }}" == "ACTIVE" ]]; then
           echo "Label predictions will now use this model." >> $GITHUB_STEP_SUMMARY

--- a/train/action.yml
+++ b/train/action.yml
@@ -1,9 +1,9 @@
 name: "Train Model"
-description: "Train the Issues, Discussions, or Pull Requests model for label prediction. Discussions use the issue-like model path."
+description: "Train the Issues, Discussions, or Pull Requests model for label prediction. Each type writes its own cached model file."
 
 inputs:
   type:
-    description: "The model to train. Must be 'issues', 'discussions', or 'pulls'. Discussions use the issue-like trainer path."
+    description: "The model to train. Must be 'issues', 'discussions', or 'pulls'."
     required: true
   data_cache_key:
     description: "The cache key suffix to use for the downloaded data. Defaults to 'staged'."
@@ -34,7 +34,7 @@ runs:
       run: |
         echo "DATA_PATH=labeler-cache/${{ inputs.type }}-data.tsv" >> $GITHUB_ENV
         echo "DATA_CACHE_KEY=${{ format('issue-labeler/data/{0}/{1}', inputs.type, inputs.data_cache_key) }}" >> $GITHUB_ENV
-        echo "MODEL_PATH=labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || inputs.type == 'discussions' && 'discussions' || 'issues' }}-model.zip" >> $GITHUB_ENV
+        echo "MODEL_PATH=labeler-cache/${{ inputs.type }}-model.zip" >> $GITHUB_ENV
         echo "MODEL_CACHE_KEY=${{ format('issue-labeler/model/{0}/{1}', inputs.type, inputs.model_cache_key) }}" >> $GITHUB_ENV
 
     - name: "Check for an existing model"

--- a/train/action.yml
+++ b/train/action.yml
@@ -34,7 +34,7 @@ runs:
       run: |
         echo "DATA_PATH=labeler-cache/${{ inputs.type }}-data.tsv" >> $GITHUB_ENV
         echo "DATA_CACHE_KEY=${{ format('issue-labeler/data/{0}/{1}', inputs.type, inputs.data_cache_key) }}" >> $GITHUB_ENV
-        echo "MODEL_PATH=labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || 'issues' }}-model.zip" >> $GITHUB_ENV
+        echo "MODEL_PATH=labeler-cache/${{ inputs.type == 'pulls' && 'pulls' || inputs.type == 'discussions' && 'discussions' || 'issues' }}-model.zip" >> $GITHUB_ENV
         echo "MODEL_CACHE_KEY=${{ format('issue-labeler/model/{0}/{1}', inputs.type, inputs.model_cache_key) }}" >> $GITHUB_ENV
 
     - name: "Check for an existing model"

--- a/train/action.yml
+++ b/train/action.yml
@@ -73,9 +73,14 @@ runs:
     - name: "Run Trainer"
       shell: bash
       run: |
-        dotnet run -c Release --project "${{ github.action_path }}/../IssueLabeler/src/Trainer" -- \
-          ${{ inputs.type == 'pulls' && format('--pulls-data "{0}"', env.DATA_PATH) || format('--issues-data "{0}"', env.DATA_PATH) }} \
-          ${{ inputs.type == 'pulls' && format('--pulls-model "{0}"', env.MODEL_PATH) || format('--issues-model "{0}"', env.MODEL_PATH) }}
+        if [[ "${{ inputs.type }}" == "pulls" ]]; then
+          trainer_args=(--pulls-data "${{ env.DATA_PATH }}" --pulls-model "${{ env.MODEL_PATH }}")
+        else
+          # Discussions intentionally reuse the issues training pipeline and schema.
+          trainer_args=(--issues-data "${{ env.DATA_PATH }}" --issues-model "${{ env.MODEL_PATH }}")
+        fi
+
+        dotnet run -c Release --project "${{ github.action_path }}/../IssueLabeler/src/Trainer" -- "${trainer_args[@]}"
 
     - name: "Save Model to Cache"
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3


### PR DESCRIPTION
## Summary

Extends discussion labeling support for the issue labeler so newly created GitHub Discussions can be labeled using the same prediction pipeline and repository conventions as issues.

## Changes

### Workflows
- Split prediction into separate issue and discussion workflows so repositories can opt into each independently
- Add a discussion prediction workflow that triggers on newly created discussions and supports manual dispatch
- Keep issue prediction as its own workflow for newly opened issues and manual dispatch
- Update workflow fork checks to use `!github.event.repository.fork`
- Make manual prediction runs default to dry-run mode while automatic runs apply labels by default

### Predictor
- Add `discussions` input support so the predictor can score GitHub Discussions
- Add `Discussion` query model with GraphQL node ID support
- Add GraphQL-based discussion retrieval and label mutation support in `GitHubApi`
- Reuse the issues model and issue-shaped prediction input for discussions
- Add discussion prediction handling in `Predictor.cs`
- Add `dry_run` as the preferred action input name, while keeping `test` as a compatibility alias

## Notes

- Discussions reuse the issues model and prediction features; they do not introduce a separate model architecture
- Discussion label mutations use GraphQL so labels can be added and removed on discussions correctly
- Manual runs default to dry-run mode; automatic labeling runs are intended to apply labels
