### PR TITLE
Add multi-label prediction support via max_labels input

### DIFF
--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -24,6 +24,7 @@ env:
   LABEL_PREFIX: "area-"
   THRESHOLD: 0.40
   DEFAULT_LABEL: "needs-area-label"
+  MAX_LABELS: 2
 
 jobs:
   predict-issue-label:
@@ -50,6 +51,7 @@ jobs:
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}
+          max_labels: ${{ env.MAX_LABELS }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: ${{ !env.ALLOW_FAILURE }}

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -24,7 +24,7 @@ env:
   LABEL_PREFIX: "area-"
   THRESHOLD: 0.40
   DEFAULT_LABEL: "needs-area-label"
-  MAX_LABELS: 2
+  MAX_LABELS: "2"
 
 jobs:
   predict-issue-label:

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -24,7 +24,7 @@ env:
   LABEL_PREFIX: "area-"
   THRESHOLD: 0.40
   DEFAULT_LABEL: "needs-area-label"
-  MAX_LABELS: "2"
+  MAX_LABELS: ${{ vars.ISSUE_LABELER_MAX_LABELS || '1' }}
 
 jobs:
   predict-issue-label:

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -541,7 +541,7 @@ public class GitHubApi
             }
 
             action.WriteInfo($"""
-                [{type} {org}/{repo}#{number}] Failed to add label(s) {labelList}. {response.ReasonPhrase} ({response.StatusCode})
+                [{type} {org}/{repo}#{number}] Failed to add label(s): {labelList}. {response.ReasonPhrase} ({response.StatusCode})
                     {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
                 """);
 
@@ -549,7 +549,7 @@ public class GitHubApi
             await Task.Delay(delay * 1000);
         }
 
-        return $"Failed to add label(s) {labelList} after {retries.Length} retries.";
+        return $"Failed to add label(s): {labelList}. Performed {retries.Length} retries.";
     }
 
     /// <summary>

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -207,9 +207,10 @@ public class GitHubApi
                 }
                 else
                 {
-                    await action.WriteStatusAsync($"Waiting {retries[retry]} seconds before retry {retry + 1} of {retries.Length}...");
-                    await Task.Delay(retries[retry] * 1000);
                     retry++;
+
+                    await action.WriteStatusAsync($"Waiting {retries[retry]} seconds before retry {retry} of {retries.Length}...");
+                    await Task.Delay(retries[retry] * 1000);
 
                     continue;
                 }
@@ -542,12 +543,14 @@ public class GitHubApi
                 return null;
             }
 
+            retry++;
+
             action.WriteInfo($"""
                 [{type} {org}/{repo}#{number}] Failed to add label(s): {labelList}. {response.ReasonPhrase} ({response.StatusCode})
-                    {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    {(retry < retries.Length ? $"Will proceed with retry {retry} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
                 """);
 
-            int delay = Math.Min(retries[retry++], MaxLabelDelaySeconds);
+            int delay = Math.Min(retries[retry], MaxLabelDelaySeconds);
             await Task.Delay(delay * 1000);
         }
 
@@ -582,12 +585,14 @@ public class GitHubApi
                 return null;
             }
 
+            retry++;
+
             action.WriteInfo($"""
                 [{type} {org}/{repo}#{number}] Failed to remove label '{label}'. {response.ReasonPhrase} ({response.StatusCode})
-                    {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    {(retry < retries.Length ? $"Will proceed with retry {retry} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
                 """);
 
-            int delay = Math.Min(retries[retry++], MaxLabelDelaySeconds);
+            int delay = Math.Min(retries[retry], MaxLabelDelaySeconds);
             await Task.Delay(delay * 1000);
         }
 

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -526,7 +526,7 @@ public class GitHubApi
 
         var client = GetRestClient(githubToken);
         byte retry = 0;
-        string labelList = string.Join("', '", labels);
+        string labelList = string.Join(", ", labels.Select(label => $"'{label}'"));
 
         while (retry < retries.Length)
         {
@@ -541,7 +541,7 @@ public class GitHubApi
             }
 
             action.WriteInfo($"""
-                [{type} {org}/{repo}#{number}] Failed to add label(s) '{labelList}'. {response.ReasonPhrase} ({response.StatusCode})
+                [{type} {org}/{repo}#{number}] Failed to add label(s) {labelList}. {response.ReasonPhrase} ({response.StatusCode})
                     {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
                 """);
 
@@ -549,7 +549,7 @@ public class GitHubApi
             await Task.Delay(delay * 1000);
         }
 
-        return $"Failed to add label(s) '{labelList}' after {retries.Length} retries.";
+        return $"Failed to add label(s) {labelList} after {retries.Length} retries.";
     }
 
     /// <summary>

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -474,17 +474,19 @@ public class GitHubApi
             )
             {
                 // Retry on exceptions as they can be temporary network issues
+                retry++;
+
                 action.WriteInfo($"""
                     [{typeName} {org}/{repo}#{number}] Failed to retrieve data.
                         Exception caught during query.
 
                         {ex.Message}
 
-                        {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                        {(retry < retries.Length ? $"Will proceed with retry {retry} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
                     """);
             }
 
-            await Task.Delay(retries[retry++] * 1000);
+            await Task.Delay(retries[retry] * 1000);
         }
 
         return null;

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -502,16 +502,37 @@ public class GitHubApi
     /// <param name="retries">An array of retry delays in seconds. A maximum delay of 30 seconds is enforced.</param>
     /// <param name="action">The GitHub action service.</param>
     /// <returns>A string describing a failure, or <c>null</c> if successful.</returns>
-    public static async Task<string?> AddLabel(string githubToken, string org, string repo, string type, ulong number, string label, int[] retries, ICoreService action)
+    public static async Task<string?> AddLabel(string githubToken, string org, string repo, string type, ulong number, string label, int[] retries, ICoreService action) =>
+        await AddLabels(githubToken, org, repo, type, number, [label], retries, action);
+
+    /// <summary>
+    /// Adds labels to an issue or pull request in a GitHub repository.
+    /// </summary>
+    /// <param name="githubToken">The GitHub token to use for authentication.</param>
+    /// <param name="org">The GitHub organization name.</param>
+    /// <param name="repo">The GitHub repository name.</param>
+    /// <param name="type">The type of item (e.g., "issue" or "pull request").</param>
+    /// <param name="number">The issue or pull request number.</param>
+    /// <param name="labels">The labels to add.</param>
+    /// <param name="retries">An array of retry delays in seconds. A maximum delay of 30 seconds is enforced.</param>
+    /// <param name="action">The GitHub action service.</param>
+    /// <returns>A string describing a failure, or <c>null</c> if successful.</returns>
+    public static async Task<string?> AddLabels(string githubToken, string org, string repo, string type, ulong number, string[] labels, int[] retries, ICoreService action)
     {
+        if (labels.Length == 0)
+        {
+            return null;
+        }
+
         var client = GetRestClient(githubToken);
         byte retry = 0;
+        string labelList = string.Join("', '", labels);
 
         while (retry < retries.Length)
         {
             var response = await client.PostAsJsonAsync(
                 $"https://api.github.com/repos/{org}/{repo}/issues/{number}/labels",
-                new string[] { label },
+                labels,
                 CancellationToken.None);
 
             if (response.IsSuccessStatusCode)
@@ -520,7 +541,7 @@ public class GitHubApi
             }
 
             action.WriteInfo($"""
-                [{type} {org}/{repo}#{number}] Failed to add label '{label}'. {response.ReasonPhrase} ({response.StatusCode})
+                [{type} {org}/{repo}#{number}] Failed to add label(s) '{labelList}'. {response.ReasonPhrase} ({response.StatusCode})
                     {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
                 """);
 
@@ -528,7 +549,7 @@ public class GitHubApi
             await Task.Delay(delay * 1000);
         }
 
-        return $"Failed to add label '{label}' after {retries.Length} retries.";
+        return $"Failed to add label(s) '{labelList}' after {retries.Length} retries.";
     }
 
     /// <summary>

--- a/IssueLabeler/src/GitHubClient/GitHubApi.cs
+++ b/IssueLabeler/src/GitHubClient/GitHubApi.cs
@@ -190,7 +190,9 @@ public class GitHubApi
             {
                 action.WriteInfo($"Exception caught during query.\n  {ex.Message}");
 
-                if (retry >= retries.Length - 1)
+                int retryDelay = retries[retry++];
+
+                if (retry >= retries.Length)
                 {
                     await action.WriteStatusAsync($"Retry limit of {retries.Length} reached. Aborting.");
 
@@ -207,10 +209,8 @@ public class GitHubApi
                 }
                 else
                 {
-                    retry++;
-
-                    await action.WriteStatusAsync($"Waiting {retries[retry]} seconds before retry {retry} of {retries.Length}...");
-                    await Task.Delay(retries[retry] * 1000);
+                    await action.WriteStatusAsync($"Waiting {retryDelay} seconds before retry {retry} of {retries.Length}...");
+                    await Task.Delay(retryDelay * 1000);
 
                     continue;
                 }
@@ -420,6 +420,8 @@ public class GitHubApi
 
         while (retry < retries.Length)
         {
+            int retryDelay = retries[retry++];
+
             try
             {
                 var response = await client.SendQueryAsync<RepositoryQuery<T>>(query);
@@ -437,7 +439,7 @@ public class GitHubApi
                         action.WriteInfo($"""
                             [{typeName} {org}/{repo}#{number}] Failed to retrieve data.
                                 Rate limit has been reached.
-                                {(retry < retries.Length ? $"Will proceed with retry {retry + 1} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                                {(retry < retries.Length ? $"Will proceed with retry {retry} of {retries.Length} after {retryDelay} seconds..." : $"Retry limit of {retries.Length} reached.")}
                             """);
                     }
                     else
@@ -475,19 +477,17 @@ public class GitHubApi
             )
             {
                 // Retry on exceptions as they can be temporary network issues
-                retry++;
-
                 action.WriteInfo($"""
                     [{typeName} {org}/{repo}#{number}] Failed to retrieve data.
                         Exception caught during query.
 
                         {ex.Message}
 
-                        {(retry < retries.Length ? $"Will proceed with retry {retry} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                        {(retry < retries.Length ? $"Will proceed with retry {retry} of {retries.Length} after {retryDelay} seconds..." : $"Retry limit of {retries.Length} reached.")}
                     """);
             }
 
-            await Task.Delay(retries[retry] * 1000);
+            await Task.Delay(retryDelay * 1000);
         }
 
         return null;
@@ -533,6 +533,8 @@ public class GitHubApi
 
         while (retry < retries.Length)
         {
+            int retryDelay = Math.Min(retries[retry++], MaxLabelDelaySeconds);
+
             var response = await client.PostAsJsonAsync(
                 $"https://api.github.com/repos/{org}/{repo}/issues/{number}/labels",
                 labels,
@@ -543,15 +545,12 @@ public class GitHubApi
                 return null;
             }
 
-            retry++;
-
             action.WriteInfo($"""
                 [{type} {org}/{repo}#{number}] Failed to add label(s): {labelList}. {response.ReasonPhrase} ({response.StatusCode})
-                    {(retry < retries.Length ? $"Will proceed with retry {retry} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    {(retry < retries.Length ? $"Will proceed with retry {retry} of {retries.Length} after {retryDelay} seconds..." : $"Retry limit of {retries.Length} reached.")}
                 """);
 
-            int delay = Math.Min(retries[retry], MaxLabelDelaySeconds);
-            await Task.Delay(delay * 1000);
+            await Task.Delay(retryDelay * 1000);
         }
 
         return $"Failed to add label(s): {labelList}. Performed {retries.Length} retries.";
@@ -585,15 +584,14 @@ public class GitHubApi
                 return null;
             }
 
-            retry++;
+            int retryDelay = Math.Min(retries[retry++], MaxLabelDelaySeconds);
 
             action.WriteInfo($"""
                 [{type} {org}/{repo}#{number}] Failed to remove label '{label}'. {response.ReasonPhrase} ({response.StatusCode})
-                    {(retry < retries.Length ? $"Will proceed with retry {retry} of {retries.Length} after {retries[retry]} seconds..." : $"Retry limit of {retries.Length} reached.")}
+                    {(retry < retries.Length ? $"Will proceed with retry {retry} of {retries.Length} after {retryDelay} seconds..." : $"Retry limit of {retries.Length} reached.")}
                 """);
 
-            int delay = Math.Min(retries[retry], MaxLabelDelaySeconds);
-            await Task.Delay(delay * 1000);
+            await Task.Delay(retryDelay * 1000);
         }
 
         return $"Failed to remove label '{label}' after {retries.Length} retries.";

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -5,7 +5,7 @@ using Actions.Core.Services;
 
 public struct Args
 {
-    private const int MaxLabelsLimit = 2;
+    private const byte MaxLabelsLimit = 10;
 
     public string GitHubToken => Environment.GetEnvironmentVariable("GITHUB_TOKEN")!;
     public string Org { get; set; }
@@ -18,7 +18,7 @@ public struct Args
     public string? PullsModelPath { get; set; }
     public List<ulong>? Pulls { get; set; }
     public string? DefaultLabel { get; set; }
-    public int MaxLabels { get; set; }
+    public byte MaxLabels { get; set; }
     public int[] Retries { get; set; }
     public bool Verbose { get; set; }
     public bool Test { get; set; }
@@ -54,7 +54,7 @@ public struct Args
                                       Defaults to: 0.4.
               DEFAULT_LABEL           Label to apply if no label is predicted.
               MAX_LABELS              Maximum number of labels to apply when multiple predictions
-                                      meet the threshold. Must be a positive integer in [1, 2].
+                                      meet the threshold. Must be a positive integer in [1, 10].
                                       Defaults to: 1.
               EXCLUDED_AUTHORS        Comma-separated list of authors to exclude.
               RETRIES                 Comma-separated retry delays in seconds.
@@ -82,7 +82,7 @@ public struct Args
         argUtils.TryGetIntArray("retries", out var retries);
         argUtils.TryGetString("default_label", out var defaultLabel);
         argUtils.TryGetString("max_labels", out var maxLabelsStr);
-        int? maxLabels = null;
+        byte? maxLabels = null;
         if (maxLabelsStr is not null)
         {
             maxLabelsStr = maxLabelsStr.Trim();
@@ -91,7 +91,7 @@ public struct Args
             {
                 maxLabelsStr = null;
             }
-            else if (!int.TryParse(maxLabelsStr, out int parsedMaxLabels) || parsedMaxLabels < 1 || parsedMaxLabels > MaxLabelsLimit)
+            else if (!byte.TryParse(maxLabelsStr, out byte parsedMaxLabels) || parsedMaxLabels < 1 || parsedMaxLabels > MaxLabelsLimit)
             {
                 ShowUsage($"Input 'max_labels' must be a positive integer between 1 and {MaxLabelsLimit}.", action);
                 return null;

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -5,7 +5,7 @@ using Actions.Core.Services;
 
 public struct Args
 {
-    private const int MaxLabelsLimit = 5;
+    private const int MaxLabelsLimit = 2;
 
     public string GitHubToken => Environment.GetEnvironmentVariable("GITHUB_TOKEN")!;
     public string Org { get; set; }
@@ -54,7 +54,7 @@ public struct Args
                                       Defaults to: 0.4.
               DEFAULT_LABEL           Label to apply if no label is predicted.
               MAX_LABELS              Maximum number of labels to apply when multiple predictions
-                                      meet the threshold. Must be a positive integer in [1, 5].
+                                      meet the threshold. Must be a positive integer in [1, 2].
                                       Defaults to: 1.
               EXCLUDED_AUTHORS        Comma-separated list of authors to exclude.
               RETRIES                 Comma-separated retry delays in seconds.

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -85,12 +85,21 @@ public struct Args
         int? maxLabels = null;
         if (maxLabelsStr is not null)
         {
-            if (!int.TryParse(maxLabelsStr, out int parsedMaxLabels) || parsedMaxLabels < 1 || parsedMaxLabels > MaxLabelsLimit)
+            maxLabelsStr = maxLabelsStr.Trim();
+
+            if (maxLabelsStr.Length == 0)
+            {
+                maxLabelsStr = null;
+            }
+            else if (!int.TryParse(maxLabelsStr, out int parsedMaxLabels) || parsedMaxLabels < 1 || parsedMaxLabels > MaxLabelsLimit)
             {
                 ShowUsage($"Input 'max_labels' must be a positive integer between 1 and {MaxLabelsLimit}.", action);
                 return null;
             }
-            maxLabels = parsedMaxLabels;
+            else
+            {
+                maxLabels = parsedMaxLabels;
+            }
         }
         argUtils.TryGetFlag("test", out var test);
         argUtils.TryGetFlag("verbose", out var verbose);

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -5,6 +5,8 @@ using Actions.Core.Services;
 
 public struct Args
 {
+    private const int MaxLabelsLimit = 5;
+
     public string GitHubToken => Environment.GetEnvironmentVariable("GITHUB_TOKEN")!;
     public string Org { get; set; }
     public string Repo { get; set; }
@@ -52,7 +54,8 @@ public struct Args
                                       Defaults to: 0.4.
               DEFAULT_LABEL           Label to apply if no label is predicted.
               MAX_LABELS              Maximum number of labels to apply when multiple predictions
-                                      meet the threshold. Must be a positive integer. Defaults to: 1.
+                                      meet the threshold. Must be a positive integer in [1, 5].
+                                      Defaults to: 1.
               EXCLUDED_AUTHORS        Comma-separated list of authors to exclude.
               RETRIES                 Comma-separated retry delays in seconds.
                                       Defaults to: 30,30,300,300,3000,3000.
@@ -82,9 +85,9 @@ public struct Args
         int? maxLabels = null;
         if (maxLabelsStr is not null)
         {
-            if (!int.TryParse(maxLabelsStr, out int parsedMaxLabels) || parsedMaxLabels < 1)
+            if (!int.TryParse(maxLabelsStr, out int parsedMaxLabels) || parsedMaxLabels < 1 || parsedMaxLabels > MaxLabelsLimit)
             {
-                ShowUsage("Input 'max_labels' must be a positive integer (>= 1).", action);
+                ShowUsage($"Input 'max_labels' must be a positive integer between 1 and {MaxLabelsLimit}.", action);
                 return null;
             }
             maxLabels = parsedMaxLabels;

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -16,6 +16,7 @@ public struct Args
     public string? PullsModelPath { get; set; }
     public List<ulong>? Pulls { get; set; }
     public string? DefaultLabel { get; set; }
+    public int MaxLabels { get; set; }
     public int[] Retries { get; set; }
     public bool Verbose { get; set; }
     public bool Test { get; set; }
@@ -50,6 +51,8 @@ public struct Args
               THRESHOLD               Minimum prediction confidence threshold. Range (0,1].
                                       Defaults to: 0.4.
               DEFAULT_LABEL           Label to apply if no label is predicted.
+              MAX_LABELS              Maximum number of labels to apply when multiple predictions
+                                      meet the threshold. Must be a positive integer. Defaults to: 1.
               EXCLUDED_AUTHORS        Comma-separated list of authors to exclude.
               RETRIES                 Comma-separated retry delays in seconds.
                                       Defaults to: 30,30,300,300,3000,3000.
@@ -75,6 +78,7 @@ public struct Args
         argUtils.TryGetFloat("threshold", out var threshold);
         argUtils.TryGetIntArray("retries", out var retries);
         argUtils.TryGetString("default_label", out var defaultLabel);
+        argUtils.TryGetInt("max_labels", out var maxLabels);
         argUtils.TryGetFlag("test", out var test);
         argUtils.TryGetFlag("verbose", out var verbose);
 
@@ -91,6 +95,7 @@ public struct Args
             Repo = repo,
             LabelPredicate = labelPredicate,
             DefaultLabel = defaultLabel,
+            MaxLabels = maxLabels ?? 1,
             IssuesModelPath = issuesModelPath,
             Issues = issues,
             PullsModelPath = pullsModelPath,

--- a/IssueLabeler/src/Predictor/Args.cs
+++ b/IssueLabeler/src/Predictor/Args.cs
@@ -78,7 +78,17 @@ public struct Args
         argUtils.TryGetFloat("threshold", out var threshold);
         argUtils.TryGetIntArray("retries", out var retries);
         argUtils.TryGetString("default_label", out var defaultLabel);
-        argUtils.TryGetInt("max_labels", out var maxLabels);
+        argUtils.TryGetString("max_labels", out var maxLabelsStr);
+        int? maxLabels = null;
+        if (maxLabelsStr is not null)
+        {
+            if (!int.TryParse(maxLabelsStr, out int parsedMaxLabels) || parsedMaxLabels < 1)
+            {
+                ShowUsage("Input 'max_labels' must be a positive integer (>= 1).", action);
+                return null;
+            }
+            maxLabels = parsedMaxLabels;
+        }
         argUtils.TryGetFlag("test", out var test);
         argUtils.TryGetFlag("verbose", out var verbose);
 

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -152,7 +152,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         {
             if (!test)
             {
-                error = await GitHubApi.RemoveLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, argsData.Retries, action);
+                error = await GitHubApi.RemoveLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, retries, action);
             }
 
             if (error is null)
@@ -239,7 +239,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         {
             if (!test)
             {
-                error = await GitHubApi.RemoveLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, argsData.Retries, action);
+                error = await GitHubApi.RemoveLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, retries, action);
             }
 
             if (error is null)

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -48,6 +48,7 @@ if (argsData.IssuesModelPath is not null && argsData.Issues is not null)
             new Issue(result),
             argsData.LabelPredicate,
             argsData.DefaultLabel,
+            argsData.MaxLabels,
             ModelType.Issue,
             argsData.Retries,
             argsData.Test
@@ -87,6 +88,7 @@ if (argsData.PullsModelPath is not null && argsData.Pulls is not null)
             new PullRequest(result),
             argsData.LabelPredicate,
             argsData.DefaultLabel,
+            argsData.MaxLabels,
             ModelType.PullRequest,
             argsData.Retries,
             argsData.Test
@@ -106,7 +108,7 @@ foreach (var prediction in predictionResults.OrderBy(p => p.Number))
 await action.Summary.WritePersistentAsync();
 return success ? 0 : 1;
 
-async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, ulong number, T issueOrPull, Func<string, bool> labelPredicate, string? defaultLabel, ModelType type, int[] retries, bool test) where T : Issue
+async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction<T>(PredictionEngine<T, LabelPrediction> predictor, ulong number, T issueOrPull, Func<string, bool> labelPredicate, string? defaultLabel, int maxLabels, ModelType type, int[] retries, bool test) where T : Issue
 {
     List<Action<Summary>> predictionResults = [];
     string typeName = type == ModelType.PullRequest ? "Pull Request" : "Issue";
@@ -195,11 +197,11 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         .OrderByDescending(p => p.Score)
         .Take(3);
 
-    var bestScore = predictions.FirstOrDefault(p => p.Score >= argsData.Threshold);
+    var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(maxLabels).ToList();
 
-    if (bestScore is not null)
+    if (topLabels.Count > 0)
     {
-        predictionResults.Add(summary => summary.AddRawMarkdown($"    - Predicted label: `{bestScore.Label}` meets the threshold of {argsData.Threshold}.", true));
+        predictionResults.Add(summary => summary.AddRawMarkdown($"    - {topLabels.Count} label(s) meet the threshold of {argsData.Threshold}.", true));
     }
     else
     {
@@ -211,49 +213,49 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         predictionResults.Add(summary => summary.AddRawMarkdown($"        - `{labelPrediction.Label}` - Score: {labelPrediction.Score}", true));
     }
 
-    if (bestScore is not null)
+    if (topLabels.Count > 0)
     {
-        if (!test)
+        foreach (var labelToApply in topLabels)
         {
-            error = await GitHubApi.AddLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, bestScore.Label, retries, action);
-        }
-
-        if (error is null)
-        {
-            predictionResults.Add(summary => summary.AddRawMarkdown($"    - **`{bestScore.Label}` applied**", true));
-            resultMessageParts.Add($"Label '{bestScore.Label}' applied.");
-
-            if (hasDefaultLabel && defaultLabel is not null)
+            if (!test)
             {
-                if (!test)
-                {
-                    error = await GitHubApi.RemoveLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, retries, action);
-                }
+                error = await GitHubApi.AddLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, labelToApply.Label, retries, action);
+            }
 
-                if (error is null)
-                {
-                    predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Removed default label `{defaultLabel}`**", true));
-                    resultMessageParts.Add($"Default label '{defaultLabel}' removed.");
-                    return Success();
-                }
-                else
-                {
-                    predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error removing default label `{defaultLabel}`**: {error}", true));
-                    resultMessageParts.Add($"Error occurred removing default label '{defaultLabel}'");
-                    return Failure();
-                }
+            if (error is null)
+            {
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **`{labelToApply.Label}` applied**", true));
+                resultMessageParts.Add($"Label '{labelToApply.Label}' applied.");
             }
             else
             {
-                return Success();
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying label `{labelToApply.Label}`**: {error}", true));
+                resultMessageParts.Add($"Error occurred applying label '{labelToApply.Label}'");
+                return Failure();
             }
         }
-        else
+
+        if (hasDefaultLabel && defaultLabel is not null)
         {
-            predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying label `{bestScore.Label}`**: {error}", true));
-            resultMessageParts.Add($"Error occurred applying label '{bestScore.Label}'");
-            return Failure();
+            if (!test)
+            {
+                error = await GitHubApi.RemoveLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, argsData.Retries, action);
+            }
+
+            if (error is null)
+            {
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Removed default label `{defaultLabel}`**", true));
+                resultMessageParts.Add($"Default label '{defaultLabel}' removed.");
+            }
+            else
+            {
+                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error removing default label `{defaultLabel}`**: {error}", true));
+                resultMessageParts.Add($"Error occurred removing default label '{defaultLabel}'");
+                return Failure();
+            }
         }
+
+        return Success();
     }
 
     if (defaultLabel is not null)

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -203,7 +203,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
 
     if (eligibleLabels.Count > 0)
     {
-        predictionResults.Add(summary => summary.AddRawMarkdown($"    - {eligibleLabels.Count} label(s) meet the threshold of {argsData.Threshold}; applying {topLabels.Count}.", true));
+        predictionResults.Add(summary => summary.AddRawMarkdown($"    - At least {eligibleLabels.Count} label(s) meet the threshold of {argsData.Threshold}; applying {topLabels.Count}.", true));
     }
     else
     {

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -164,7 +164,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
             else
             {
                 predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error removing default label `{defaultLabel}`**: {error}", true));
-                resultMessageParts.Add($"Error occurred removing default label '{defaultLabel}'");
+                resultMessageParts.Add($"Error occurred removing default label '{defaultLabel}': {error}");
                 return Failure();
             }
         }
@@ -195,7 +195,8 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         .Where(prediction => labelPredicate(prediction.Label))
         // Capture at least the top 3 for output, or more if max_labels requests it
         .OrderByDescending(p => p.Score)
-        .Take(Math.Max(3, maxLabels));
+        .Take(Math.Max(3, maxLabels))
+        .ToList();
 
     var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(maxLabels).ToList();
 
@@ -231,7 +232,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
             else
             {
                 predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying label `{labelToApply.Label}`**: {error}", true));
-                resultMessageParts.Add($"Error occurred applying label '{labelToApply.Label}'");
+                resultMessageParts.Add($"Error occurred applying label '{labelToApply.Label}': {error}");
                 return Failure();
             }
         }
@@ -251,7 +252,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
             else
             {
                 predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error removing default label `{defaultLabel}`**: {error}", true));
-                resultMessageParts.Add($"Error occurred removing default label '{defaultLabel}'");
+                resultMessageParts.Add($"Error occurred removing default label '{defaultLabel}': {error}");
                 return Failure();
             }
         }
@@ -271,7 +272,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         {
             if (!test)
             {
-                error = await GitHubApi.AddLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, argsData.Retries, action);
+                error = await GitHubApi.AddLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, retries, action);
             }
 
             if (error is null)
@@ -283,7 +284,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
             else
             {
                 predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying default label `{defaultLabel}`**: {error}", true));
-                resultMessageParts.Add($"Error occurred applying default label '{defaultLabel}'");
+                resultMessageParts.Add($"Error occurred applying default label '{defaultLabel}': {error}");
                 return Failure();
             }
         }

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -242,8 +242,8 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         else
         {
             string attemptedLabels = string.Join(", ", topLabels.Select(label => $"'{label.Label}'"));
-            predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying labels {attemptedLabels}**: {error}", true));
-            resultMessageParts.Add($"Error occurred applying labels {attemptedLabels}: {error}");
+            predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying labels: {attemptedLabels}**: {error}", true));
+            resultMessageParts.Add($"Error occurred applying labels: {attemptedLabels}. {error}");
             return Failure();
         }
 

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -198,11 +198,12 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         .Take(3)
         .ToList();
 
-    var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(maxLabels).ToList();
+    var eligibleLabels = predictions.Where(p => p.Score >= argsData.Threshold).ToList();
+    var topLabels = eligibleLabels.Take(maxLabels).ToList();
 
-    if (topLabels.Count > 0)
+    if (eligibleLabels.Count > 0)
     {
-        predictionResults.Add(summary => summary.AddRawMarkdown($"    - {topLabels.Count} label(s) meet the threshold of {argsData.Threshold}.", true));
+        predictionResults.Add(summary => summary.AddRawMarkdown($"    - {eligibleLabels.Count} label(s) meet the threshold of {argsData.Threshold}; applying {topLabels.Count}.", true));
     }
     else
     {
@@ -216,25 +217,34 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
 
     if (topLabels.Count > 0)
     {
-        foreach (var labelToApply in topLabels)
+        error = null;
+        if (!test)
         {
-            error = null;
-            if (!test)
-            {
-                error = await GitHubApi.AddLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, labelToApply.Label, retries, action);
-            }
+            error = await GitHubApi.AddLabels(
+                argsData.GitHubToken,
+                argsData.Org,
+                argsData.Repo,
+                typeName,
+                number,
+                topLabels.Select(label => label.Label).ToArray(),
+                retries,
+                action);
+        }
 
-            if (error is null)
+        if (error is null)
+        {
+            foreach (var labelToApply in topLabels)
             {
                 predictionResults.Add(summary => summary.AddRawMarkdown($"    - **`{labelToApply.Label}` applied**", true));
                 resultMessageParts.Add($"Label '{labelToApply.Label}' applied.");
             }
-            else
-            {
-                predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying label `{labelToApply.Label}`**: {error}", true));
-                resultMessageParts.Add($"Error occurred applying label '{labelToApply.Label}': {error}");
-                return Failure();
-            }
+        }
+        else
+        {
+            string attemptedLabels = string.Join("', '", topLabels.Select(label => label.Label));
+            predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying labels `{attemptedLabels}`**: {error}", true));
+            resultMessageParts.Add($"Error occurred applying labels '{attemptedLabels}': {error}");
+            return Failure();
         }
 
         if (hasDefaultLabel && defaultLabel is not null)

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -193,9 +193,9 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         })
         // Ensure predicted labels match the expected predicate
         .Where(prediction => labelPredicate(prediction.Label))
-        // Capture the top 3 for including in the output
+        // Capture at least the top 3 for output, or more if max_labels requests it
         .OrderByDescending(p => p.Score)
-        .Take(3);
+        .Take(Math.Max(3, maxLabels));
 
     var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(maxLabels).ToList();
 

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -193,9 +193,9 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         })
         // Ensure predicted labels match the expected predicate
         .Where(prediction => labelPredicate(prediction.Label))
-        // Capture the top 3 predictions for output.
+        // Capture a little extra headroom beyond what may be applied.
         .OrderByDescending(p => p.Score)
-        .Take(3)
+        .Take(maxLabels + 2)
         .ToList();
 
     var eligibleLabels = predictions.Where(p => p.Score >= argsData.Threshold).ToList();
@@ -241,9 +241,9 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         }
         else
         {
-            string attemptedLabels = string.Join("', '", topLabels.Select(label => label.Label));
-            predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying labels `{attemptedLabels}`**: {error}", true));
-            resultMessageParts.Add($"Error occurred applying labels '{attemptedLabels}': {error}");
+            string attemptedLabels = string.Join(", ", topLabels.Select(label => $"'{label.Label}'"));
+            predictionResults.Add(summary => summary.AddRawMarkdown($"    - **Error applying labels {attemptedLabels}**: {error}", true));
+            resultMessageParts.Add($"Error occurred applying labels {attemptedLabels}: {error}");
             return Failure();
         }
 

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -217,6 +217,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
     {
         foreach (var labelToApply in topLabels)
         {
+            error = null;
             if (!test)
             {
                 error = await GitHubApi.AddLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, labelToApply.Label, retries, action);

--- a/IssueLabeler/src/Predictor/Predictor.cs
+++ b/IssueLabeler/src/Predictor/Predictor.cs
@@ -193,9 +193,9 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
         })
         // Ensure predicted labels match the expected predicate
         .Where(prediction => labelPredicate(prediction.Label))
-        // Capture at least the top 3 for output, or more if max_labels requests it
+        // Capture the top 3 predictions for output.
         .OrderByDescending(p => p.Score)
-        .Take(Math.Max(3, maxLabels))
+        .Take(3)
         .ToList();
 
     var topLabels = predictions.Where(p => p.Score >= argsData.Threshold).Take(maxLabels).ToList();
@@ -239,6 +239,7 @@ async Task<(ulong Number, string ResultMessage, bool Success)> ProcessPrediction
 
         if (hasDefaultLabel && defaultLabel is not null)
         {
+            error = null;
             if (!test)
             {
                 error = await GitHubApi.RemoveLabel(argsData.GitHubToken, argsData.Org, argsData.Repo, typeName, number, defaultLabel, retries, action);

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -23,6 +23,11 @@ inputs:
   default_label:
     description: "The default label to apply if no prediction meets the threshold. Leave blank for no default label."
 
+  max_labels:
+    description: "Maximum number of labels to apply when multiple predictions meet the threshold. Defaults to 1."
+    required: false
+    default: "1"
+
   excluded_authors:
     description: "Comma-separated list of authors to exclude. Defaults to none."
 

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -22,9 +22,12 @@ inputs:
 
   default_label:
     description: "The default label to apply if no prediction meets the threshold. Leave blank for no default label."
+    required: false
 
+  max_labels:
     description: "Maximum number of labels to apply when multiple predictions meet the threshold. Must be a positive integer between 1 and 10. Defaults to 1."
-
+    required: false
+    default: "1"
   excluded_authors:
     description: "Comma-separated list of authors to exclude. Defaults to none."
 

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: "The default label to apply if no prediction meets the threshold. Leave blank for no default label."
 
   max_labels:
-    description: "Maximum number of labels to apply when multiple predictions meet the threshold. Defaults to 1."
+    description: "Maximum number of labels to apply when multiple predictions meet the threshold. Must be a positive integer between 1 and 5. Defaults to 1."
     required: false
     default: "1"
 

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -23,10 +23,7 @@ inputs:
   default_label:
     description: "The default label to apply if no prediction meets the threshold. Leave blank for no default label."
 
-  max_labels:
-    description: "Maximum number of labels to apply when multiple predictions meet the threshold. Must be a positive integer between 1 and 2. Defaults to 1."
-    required: false
-    default: "1"
+    description: "Maximum number of labels to apply when multiple predictions meet the threshold. Must be a positive integer between 1 and 10. Defaults to 1."
 
   excluded_authors:
     description: "Comma-separated list of authors to exclude. Defaults to none."

--- a/predict/action.yml
+++ b/predict/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: "The default label to apply if no prediction meets the threshold. Leave blank for no default label."
 
   max_labels:
-    description: "Maximum number of labels to apply when multiple predictions meet the threshold. Must be a positive integer between 1 and 5. Defaults to 1."
+    description: "Maximum number of labels to apply when multiple predictions meet the threshold. Must be a positive integer between 1 and 2. Defaults to 1."
     required: false
     default: "1"
 


### PR DESCRIPTION
## Summary

Allows the predictor to apply up to N labels when multiple predictions meet the confidence threshold, rather than always stopping at one.

## Changes

- Add `max_labels` input to `predict/action.yml` (default: `1`, fully backward compatible)
- Add `MaxLabels` property to `Args.cs`, parsed from the new input
- Update `ProcessPrediction` in `Predictor.cs` to iterate over the top N predictions that meet the threshold (instead of only the best one), applying each in order; returns failure fast if any label apply fails
- Wire the issues workflow so `max_labels` stays at `1` by default and can only be raised through the `ISSUE_LABELER_MAX_LABELS` repo variable

## Behavior

With `max_labels: 1` (the default), behavior is identical to before. If `ISSUE_LABELER_MAX_LABELS` is set to `2`, and both the top and second-best predictions independently meet the `threshold`, both labels are applied. The default label is still removed when at least one prediction label is applied.

## Merge sequencing

PR #107 should merge first. After that lands, this PR will be updated to resolve conflicts against the discussion-labeling changes so we keep the correct post-107 workflow and prediction behavior rather than overwriting it accidentally.