### PR TITLE
Set GH_REPO so gh cache delete can resolve the target repository in the promote action

### DIFF
--- a/promote/action.yml
+++ b/promote/action.yml
@@ -109,6 +109,7 @@ runs:
         gh cache delete "${{ env.ACTIVE_KEY }}"
       env:
         GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
 
     - name: "Save the Staged Cache Entry as the ACTIVE Cache Entry"
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3


### PR DESCRIPTION
## Summary

Fix the `Labeler: Promotion` workflow failing at the "Delete Existing Active Cache Entry" step.

## Cause

The `promote/action.yml` composite action invokes `gh cache delete` without a checkout, so `gh` has no git remote from which to infer the target repository and exits before making the API call:

```
gh cache delete "issue-labeler/model/issues/ACTIVE"
failed to determine base repo: failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

Observed in consumer runs such as [microsoft/aspire #23395851258](https://github.com/microsoft/aspire/actions/runs/23395851258) and [dotnet/sdk #17777754813](https://github.com/dotnet/sdk/actions/runs/17777754813). This is not a permissions issue — `actions: write` and `GH_TOKEN` are already set; `gh` fails before reaching the API.

## Change

- Add `GH_REPO: ${{ github.repository }}` to the env block of the "Delete Existing Active Cache Entry" step in `promote/action.yml`.

## Impact

- Consumers reference `dotnet/issue-labeler/promote@main` and need no changes on their side.
- No behavior change for `gh cache delete` other than restoring the ability to resolve the target repository.
