### PR TITLE
Update predict workflow dry_run inputs

### DIFF
--- a/.github/workflows/labeler-predict-discussions.yml
+++ b/.github/workflows/labeler-predict-discussions.yml
@@ -15,7 +15,8 @@ on:
       dry_run:
         description: "Run in dry-run mode for manual dispatches. Defaults to 'true'."
         required: false
-        default: "true"
+        type: boolean
+        default: false
       cache_key:
         description: "The cache key suffix to use for restoring the model. Defaults to 'ACTIVE'."
         required: true

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -15,7 +15,8 @@ on:
       dry_run:
         description: "Run in dry-run mode for manual dispatches. Defaults to 'true'."
         required: false
-        default: "true"
+        type: boolean
+        default: false
       cache_key:
         description: "The cache key suffix to use for restoring the model. Defaults to 'ACTIVE'."
         required: true

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -21,6 +21,11 @@ on:
       pulls:
         description: "Pull Request Numbers (comma-separated list of ranges)."
         required: true
+      dry_run:
+        description: "Run in dry-run mode for manual dispatches. Defaults to 'true'."
+        required: false
+        type: boolean
+        default: false
       cache_key:
         description: "The cache key suffix to use for restoring the model. Defaults to 'ACTIVE'."
         required: true
@@ -59,6 +64,7 @@ jobs:
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}
+          dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: ${{ !env.ALLOW_FAILURE }}


### PR DESCRIPTION
- set workflow_dispatch dry_run input type to boolean in issues, discussions, and pulls workflows
- set workflow_dispatch dry_run default to false in issues, discussions, and pulls workflows
- pass dry_run to the pulls prediction step for manual dispatch runs