### PR TITLE
Update v2.1.0 SHA pins to 460bc0f9b7a7349547c8567d2ebf752453f044a1

### DIFF
--- a/.github/workflows/labeler-cache-retention.yml
+++ b/.github/workflows/labeler-cache-retention.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         type: ["issues", "pulls", "discussions"]
     steps:
-      - uses: dotnet/issue-labeler/restore@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+      - uses: dotnet/issue-labeler/restore@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: ${{ matrix.type }}
           cache_key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/labeler-predict-discussions.yml
+++ b/.github/workflows/labeler-predict-discussions.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: "Restore discussions model from cache"
         id: restore-model
-        uses: dotnet/issue-labeler/restore@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/restore@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: discussions
           fail-on-cache-miss: ${{ !fromJSON(env.ALLOW_FAILURE) }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: "Predict discussion labels"
         if: ${{ steps.restore-model.outputs.cache-hit == 'true' }}
-        uses: dotnet/issue-labeler/predict@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/predict@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           discussions: ${{ github.event.inputs.discussions || github.event.discussion.number }}
           label_prefix: ${{ env.LABEL_PREFIX }}

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: "Restore issues model from cache"
         id: restore-model
-        uses: dotnet/issue-labeler/restore@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/restore@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: issues
           fail-on-cache-miss: ${{ !fromJSON(env.ALLOW_FAILURE) }}
@@ -51,7 +51,7 @@ jobs:
       - name: "Predict issue labels"
         id: prediction
         if: ${{ steps.restore-model.outputs.cache-hit == 'true' }}
-        uses: dotnet/issue-labeler/predict@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/predict@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           issues: ${{ github.event.inputs.issues || github.event.issue.number }}
           label_prefix: ${{ env.LABEL_PREFIX }}

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: "Restore pulls model from cache"
         id: restore-model
-        uses: dotnet/issue-labeler/restore@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/restore@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: pulls
           fail-on-cache-miss: ${{ !fromJSON(env.ALLOW_FAILURE) }}
@@ -63,7 +63,7 @@ jobs:
       - name: "Predict pull labels"
         id: prediction
         if: ${{ steps.restore-model.outputs.cache-hit == 'true' }}
-        uses: dotnet/issue-labeler/predict@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/predict@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           pulls: ${{ github.event.inputs.pulls || github.event.number }}
           label_prefix: ${{ env.LABEL_PREFIX }}

--- a/.github/workflows/labeler-promote.yml
+++ b/.github/workflows/labeler-promote.yml
@@ -37,7 +37,7 @@ jobs:
       actions: write
     steps:
       - name: "Promote Model for Issues"
-        uses: dotnet/issue-labeler/promote@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/promote@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "issues"
           staged_key: ${{ github.event.inputs.staged_key }}
@@ -50,7 +50,7 @@ jobs:
       actions: write
     steps:
       - name: "Promote Model for Pull Requests"
-        uses: dotnet/issue-labeler/promote@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/promote@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "pulls"
           staged_key: ${{ github.event.inputs.staged_key }}
@@ -63,7 +63,7 @@ jobs:
       actions: write
     steps:
       - name: "Promote Model for Discussions"
-        uses: dotnet/issue-labeler/promote@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/promote@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "discussions"
           staged_key: ${{ github.event.inputs.staged_key }}

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -63,7 +63,7 @@ jobs:
       issues: read
     steps:
       - name: "Download Issues"
-        uses: dotnet/issue-labeler/download@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/download@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "issues"
           cache_key: ${{ env.CACHE_KEY }}
@@ -82,7 +82,7 @@ jobs:
       pull-requests: read
     steps:
       - name: "Download Pull Requests"
-        uses: dotnet/issue-labeler/download@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/download@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "pulls"
           cache_key: ${{ env.CACHE_KEY }}
@@ -101,7 +101,7 @@ jobs:
       discussions: read
     steps:
       - name: "Download Discussions"
-        uses: dotnet/issue-labeler/download@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/download@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "discussions"
           cache_key: ${{ env.CACHE_KEY }}
@@ -206,7 +206,7 @@ jobs:
       - check-discussions-data
     steps:
       - name: "Train Model for Discussions"
-        uses: dotnet/issue-labeler/train@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/train@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "discussions"
           data_cache_key: ${{ env.CACHE_KEY }}
@@ -221,7 +221,7 @@ jobs:
       - check-issues-data
     steps:
       - name: "Train Model for Issues"
-        uses: dotnet/issue-labeler/train@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/train@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "issues"
           data_cache_key: ${{ env.CACHE_KEY }}
@@ -236,7 +236,7 @@ jobs:
       - check-pulls-data
     steps:
       - name: "Train Model for Pull Requests"
-        uses: dotnet/issue-labeler/train@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/train@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "pulls"
           data_cache_key: ${{ env.CACHE_KEY }}
@@ -252,7 +252,7 @@ jobs:
       - train-issues
     steps:
       - name: "Test Model for Issues"
-        uses: dotnet/issue-labeler/test@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/test@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "issues"
           cache_key: ${{ env.CACHE_KEY }}
@@ -275,7 +275,7 @@ jobs:
       - train-discussions
     steps:
       - name: "Test Model for Discussions"
-        uses: dotnet/issue-labeler/test@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/test@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "discussions"
           cache_key: ${{ env.CACHE_KEY }}
@@ -298,7 +298,7 @@ jobs:
       - train-pulls
     steps:
       - name: "Test Model for Pull Requests"
-        uses: dotnet/issue-labeler/test@00ce11f3eef738334ec9092ead6e5f34db9218a4 # v2.1.0
+        uses: dotnet/issue-labeler/test@460bc0f9b7a7349547c8567d2ebf752453f044a1 # v2.1.0
         with:
           type: "pulls"
           cache_key: ${{ env.CACHE_KEY }}


### PR DESCRIPTION
- .github/workflows/labeler-cache-retention.yml: restore action
- .github/workflows/labeler-predict-discussions.yml: restore, predict actions
- .github/workflows/labeler-predict-issues.yml: restore, predict actions
- .github/workflows/labeler-predict-pulls.yml: restore, predict actions
- .github/workflows/labeler-promote.yml: promote action (issues, pulls, discussions)
- .github/workflows/labeler-train.yml: download, train, test actions (issues, pulls, discussions)